### PR TITLE
Fix identifying remote repo for customizations

### DIFF
--- a/framework/customize
+++ b/framework/customize
@@ -93,6 +93,10 @@ _customize_ensure_gh () {
     debug 'gh not found, installing'
     brew install gh
   fi
+
+  if ! gh api /user > /dev/null 2>&1; then
+    gh auth login
+  fi
 }
 
 _customize_ensure_jq () {

--- a/framework/customize
+++ b/framework/customize
@@ -137,7 +137,7 @@ _customize_has_local_git_repo () {
 
 _customize_has_remote_repo () {
   _customize_ensure_gh
-  if gh repo "$(_customize_github_get_user)/$DOTFILES_CUSTOM_REPO" > /dev/null 2>&1; then
+  if gh repo view "$(_customize_github_get_repo)" > /dev/null 2>&1; then
     return 0
   fi
 


### PR DESCRIPTION
Fixes for the customize process of cloning a remote repo:
- `gh` needs to be logged in, but if it isn't the test fails which assumes there is no remote repo.
- The test for if a repo exists always failed.