### PR TITLE
feat(nix): render Nerd Font in iTerm2 + Terminal.app

### DIFF
--- a/docs/superpowers/plans/2026-05-28-nix-terminal-fonts.md
+++ b/docs/superpowers/plans/2026-05-28-nix-terminal-fonts.md
@@ -1,5 +1,18 @@
 # Nix Terminal Fonts Slice Implementation Plan
 
+> **REVISED DURING IMPLEMENTATION — approach pivoted.** The dynamic-profile +
+> `Default Bookmark Guid` mechanism described in Task 1 Steps 3–10 below was
+> abandoned: dynamic profiles create *parallel* profiles that don't auto-take-over
+> the default/tmux roles (the `Default Bookmark Guid` pref is clobbered by a
+> running iTerm, and tmux isn't GUID-pinned). The shipped approach patches the
+> font onto the **existing** Default/tmux iTerm profiles and Terminal's Homebrew
+> profile **in place**, via a Python `plistlib` `defaults export → modify →
+> import` round-trip (`nix/profiles/default/patch-terminal-fonts.py`). See the
+> design spec's **Decision 1** for the rationale. The steps below are retained
+> for historical context; the spec is authoritative. The key constraint
+> (**quit iTerm + Terminal.app during `./apply`**) and the file-removal of the
+> stale `com.googlecode.iterm2` block (Task 1 Step 5) still hold.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
 
 **Goal:** Make iTerm2 (Default + tmux profiles) and Terminal.app (Homebrew profile) render `MesloLGSNF-Regular 14` declaratively. iTerm via two Dynamic Profiles inheriting the existing profiles + `Default Bookmark Guid`; Terminal.app via a stored NSFont blob injected by a `defaults export → plutil -replace → defaults import` activation. Remove the stale, ignored iTerm font keys the nix-firstrun slice added to `nix/darwin/defaults.nix`.

--- a/docs/superpowers/plans/2026-05-28-nix-terminal-fonts.md
+++ b/docs/superpowers/plans/2026-05-28-nix-terminal-fonts.md
@@ -1,0 +1,260 @@
+# Nix Terminal Fonts Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make iTerm2 (Default + tmux profiles) and Terminal.app (Homebrew profile) render `MesloLGSNF-Regular 14` declaratively. iTerm via two Dynamic Profiles inheriting the existing profiles + `Default Bookmark Guid`; Terminal.app via a stored NSFont blob injected by a `defaults export → plutil -replace → defaults import` activation. Remove the stale, ignored iTerm font keys the nix-firstrun slice added to `nix/darwin/defaults.nix`.
+
+**Architecture:** One atomic `feat` commit: new `nix/profiles/default/terminal-fonts.nix` (darwin-gated), import it in `nix/profiles/default/default.nix`, and remove the `com.googlecode.iterm2` block from `nix/darwin/defaults.nix`. A `docs` commit for `nix/README.md`. A verification task (heavy on manual visual checks — the payoff is glyph rendering).
+
+**Tech Stack:** Nix flakes, home-manager (`release-26.05`), `home.file`, `targets.darwin.defaults`, `lib.hm.dag` activation, `lib.mkIf pkgs.stdenv.isDarwin`, `defaults`/`plutil` (Terminal.app injection).
+
+---
+
+## Notes for the executor
+
+- **Reference spec:** `docs/superpowers/specs/2026-05-28-nix-terminal-fonts-design.md`. The full `terminal-fonts.nix` content (incl. GUIDs and the base64 blob) is authoritative.
+- **No automated tests.** Verification is `nix eval` gates + post-apply `defaults read` + manual visual confirmation (Task 3).
+- **Branch:** `nix-terminal-fonts`. Stacks on `nix-homedir` (#75). **Do NOT merge.**
+- **Sandbox disable** for `nix`, `git commit` (gpg), anything reading/writing `~/Library/...`. `nix eval` form: `nix eval "path:./nix#…"`.
+- **`./apply` needs interactive sudo (TTY).** At the apply step, run eval gates first, report NEEDS_CONTEXT, ask the user to run `./apply` (and to quit Terminal.app first — see below). Resume after.
+- **Conventional commits**, no Claude attribution. **No push** without user approval.
+
+### Pre-existing local state (assume)
+
+- iTerm profiles: "Default" GUID `BC395EC2-C211-4986-9CE6-95AA344E7D49` (also the current `Default Bookmark Guid`), "tmux" GUID `B419BC64-4E86-469D-BFD0-BB754E078C1A`. Both currently `Monaco 20`.
+- `~/Library/Application Support/iTerm2/DynamicProfiles/` exists, empty.
+- Terminal.app default+startup profile is "Homebrew"; its `Font` is a binary NSFont blob.
+- `nix/profiles/default/default.nix` imports `./claude.nix` and `./cli-tools.nix`.
+- `nix/darwin/defaults.nix` has a `CustomUserPreferences."com.googlecode.iterm2"` block (stale font keys from nix-firstrun).
+- The fixed GUIDs for this slice: Default `95362E86-C10E-48E3-9FA1-DC4596B0F677`, tmux `BF5B17AC-8CB2-4C36-942E-F45E91EAF11A`.
+
+### Open-question gates (from spec)
+
+1. **`targets.darwin.defaults` shape** — confirm `targets.darwin.defaults."com.googlecode.iterm2"."Default Bookmark Guid"` is a valid option at this pin (the `modules/targets/darwin/user-defaults` module exists). If it errors at eval, fall back to a small `home.activation` running `defaults write com.googlecode.iterm2 "Default Bookmark Guid" <guid>`.
+2. **`plutil -replace` keypath** — at apply time, confirm `plutil -replace 'Window Settings.Homebrew.Font' -data <b64> <file>` targets the nested key. Fallback: Python `plistlib` round-trip (documented in spec open-question 1).
+3. **iTerm dynamic-profile key casing** — `"Use Non-ASCII Font"` / `"Non Ascii Font"` read correctly from JSON. Verified visually at apply.
+
+---
+
+## Task 1: Atomic terminal-fonts migration
+
+**Files:**
+- Create: `nix/profiles/default/terminal-fonts.nix`
+- Modify: `nix/profiles/default/default.nix` (import)
+- Modify: `nix/darwin/defaults.nix` (remove iTerm block)
+
+### Step-by-step
+
+- [ ] **Step 1: Pre-flight capture**
+
+```bash
+{
+  echo "=== iTerm profiles font (expect Monaco 20) ==="
+  defaults read com.googlecode.iterm2 "New Bookmarks" 2>/dev/null | grep -E "Name =|Normal Font =|Guid ="
+  echo "=== Default Bookmark Guid (expect BC395EC2-...) ==="
+  defaults read com.googlecode.iterm2 "Default Bookmark Guid" 2>&1
+  echo "=== DynamicProfiles dir ==="
+  ls -la "$HOME/Library/Application Support/iTerm2/DynamicProfiles/" 2>&1
+  echo "=== Terminal Homebrew font blob (current) ==="
+  defaults read com.apple.Terminal "Window Settings.Homebrew.Font" 2>&1 | head -3
+} > "$TMPDIR/termfonts-preflight.txt" 2>&1
+cat "$TMPDIR/termfonts-preflight.txt"
+```
+
+- [ ] **Step 2: Confirm starting file state**
+
+```bash
+grep -n "com.googlecode.iterm2" nix/darwin/defaults.nix
+cat nix/profiles/default/default.nix
+ls nix/profiles/default/terminal-fonts.nix 2>&1 || echo "(not yet created — good)"
+```
+
+Expected: the `com.googlecode.iterm2` block present in defaults.nix; default.nix imports claude+cli-tools; terminal-fonts.nix absent.
+
+- [ ] **Step 3: Create `nix/profiles/default/terminal-fonts.nix`**
+
+Use the EXACT module content from the spec ("`nix/profiles/default/terminal-fonts.nix` (full content)") — including the `font` let-binding, the two GUIDs, the `terminalFontBlob` base64 string + its regen comment, the `iterm2DynamicProfiles` attrset, the `home.file` for the dynamic profile JSON, the `targets.darwin.defaults` Default Bookmark Guid, and the `home.activation.terminalAppFont` (export → plutil -replace → import). Wrap the whole config body in `lib.mkIf pkgs.stdenv.isDarwin`.
+
+Copy the base64 blob verbatim from the spec (do not regenerate — the spec's blob is the reference value).
+
+- [ ] **Step 4: Import in `nix/profiles/default/default.nix`**
+
+Add `./terminal-fonts.nix` to the imports list (alphabetical: after `./cli-tools.nix`):
+
+```nix
+  imports = [
+    ./claude.nix
+    ./cli-tools.nix
+    ./terminal-fonts.nix
+  ];
+```
+
+Do NOT touch the `programs.git.settings` block below it.
+
+- [ ] **Step 5: Remove the stale iTerm block from `nix/darwin/defaults.nix`**
+
+Find the `# ----- iTerm 2 -----` comment block and the `"com.googlecode.iterm2" = { ... };` entry under `CustomUserPreferences`, and delete the whole entry (comment + attrset). Leave all other `CustomUserPreferences` domains intact.
+
+Verify:
+```bash
+grep -n "com.googlecode.iterm2\|iTerm" nix/darwin/defaults.nix && echo "STILL PRESENT (FAIL)" || echo "OK: iTerm block removed"
+```
+
+- [ ] **Step 6: Eval gates (HARD — pre-apply)**
+
+```bash
+cd nix; git add -A ..  # stage so the flake (git source) sees terminal-fonts.nix; or: git add the new file
+SYSTEM="$(nix eval --raw --impure --expr builtins.currentSystem)"
+
+echo "=== dynamic-profile file present in home.file? ==="
+nix eval --json "path:.#homeConfigurations.default@${SYSTEM}.config.home.file" --apply 'builtins.attrNames' 2>&1 | tr ',' '\n' | grep -i "DynamicProfiles/nix.json"
+
+echo "=== Default Bookmark Guid set via targets.darwin.defaults? ==="
+nix eval --raw "path:.#homeConfigurations.default@${SYSTEM}.config.targets.darwin.defaults.\"com.googlecode.iterm2\".\"Default Bookmark Guid\"" 2>&1 | tail -2
+
+echo "=== terminalAppFont activation present? ==="
+nix eval "path:.#homeConfigurations.default@${SYSTEM}.config.home.activation.terminalAppFont.data" 2>&1 | grep -ci "plutil\|defaults import" 
+
+echo "=== darwin defaults.nix no longer references iterm2 ==="
+nix eval "path:.#darwinConfigurations.default@${SYSTEM}.config.system.defaults.CustomUserPreferences" --apply 'p: builtins.hasAttr "com.googlecode.iterm2" p' 2>&1 | tail -1
+cd ..
+```
+
+Expected: dynamic-profile path present; Default Bookmark Guid = `95362E86-…`; terminalAppFont contains plutil/defaults import; the darwin CustomUserPreferences `com.googlecode.iterm2` check → `false`.
+
+If `targets.darwin.defaults` errors → open-question-1 fallback (home.activation defaults write). Re-eval until green. Do NOT apply until clean.
+
+- [ ] **Step 7: Full flake eval (both profiles)**
+
+```bash
+SYSTEM="$(nix eval --raw --impure --expr builtins.currentSystem)"
+nix flake check --no-build path:./nix 2>&1 | tail -20
+nix eval "path:./nix#homeConfigurations.default@${SYSTEM}.config.home.activationPackage.drvPath" 2>&1 | tail -3
+# Confirm the isDarwin guard makes the linux build a no-op (no DynamicProfiles file there):
+nix eval --json "path:./nix#homeConfigurations.default@x86_64-linux.config.home.file" --apply 'fs: builtins.any (n: builtins.match ".*DynamicProfiles.*" n != null) (builtins.attrNames fs)' 2>&1 | tail -1
+```
+
+Expected: flake check + darwin drv eval succeed; the linux check → `false` (guard works).
+
+- [ ] **Step 8: Run `./apply`**
+
+Needs interactive sudo. Report NEEDS_CONTEXT and ask the user to **quit Terminal.app first**, then run `./apply`. Resume from Step 9. (iTerm can stay open — dynamic profiles are clobber-immune; but Terminal.app must be quit so the import isn't reverted on its next quit.)
+
+- [ ] **Step 9: Verify iTerm dynamic profiles + default bookmark**
+
+```bash
+echo "=== dynamic profile file ==="
+ls -la "$HOME/Library/Application Support/iTerm2/DynamicProfiles/nix.json"
+cat "$HOME/Library/Application Support/iTerm2/DynamicProfiles/nix.json" | python3 -m json.tool 2>/dev/null | grep -E '"Name"|"Normal Font"|"Dynamic Profile Parent Name"|"Guid"'
+echo "=== Default Bookmark Guid (expect 95362E86-...) ==="
+defaults read com.googlecode.iterm2 "Default Bookmark Guid" 2>&1
+```
+
+Expected: nix.json is a symlink containing both profiles with `MesloLGSNF-Regular 14` and the right parents; Default Bookmark Guid = `95362E86-C10E-48E3-9FA1-DC4596B0F677`.
+
+- [ ] **Step 10: Verify Terminal.app font blob**
+
+```bash
+echo "=== Homebrew profile font (decode the NSFont) ==="
+defaults read com.apple.Terminal "Window Settings.Homebrew.Font" 2>&1 | head -3
+# Decode to confirm it names MesloLGSNF-Regular:
+python3 - <<'PY'
+import subprocess, plistlib, base64
+out = subprocess.run(["defaults","export","com.apple.Terminal","-"], capture_output=True).stdout
+pl = plistlib.loads(out)
+blob = pl["Window Settings"]["Homebrew"]["Font"]
+# blob is bytes (NSFont archive); search for the font name
+print("MesloLGSNF-Regular" in blob.decode("latin-1") and "OK: Terminal Homebrew font is MesloLGSNF-Regular" or "FAIL: font name not found in blob")
+PY
+```
+
+Expected: the blob decodes to contain `MesloLGSNF-Regular`. If the round-trip didn't take (e.g. Terminal was running), note it; the user re-applies with Terminal quit.
+
+- [ ] **Step 11: Manual visual verification (executor cannot do — flag for user)**
+
+These require a human; document them for the user to confirm in Task 3:
+- Relaunch iTerm → the Default window uses MesloLGS Nerd Font; starship's git-branch glyph renders (no missing-glyph box).
+- In iTerm, select the `tmux (nix)` profile for a tmux window → Nerd Font renders there too.
+- Quit + reopen Terminal.app → the Homebrew profile shows MesloLGS Nerd Font 14.
+
+The executor records these as "pending user visual confirmation" rather than blocking the commit.
+
+- [ ] **Step 12: Stage and commit**
+
+```bash
+git add nix/profiles/default/terminal-fonts.nix nix/profiles/default/default.nix nix/darwin/defaults.nix
+git status
+git commit -m "$(cat <<'EOF'
+feat(nix): render Nerd Font in iTerm2 + Terminal.app declaratively
+
+Close the terminal-font deferral. The nix-firstrun attempt wrote a top-level
+iTerm `Normal Font` pref (ignored — the font lives per-profile in New Bookmarks)
+with a typo'd PostScript name. This does it correctly:
+
+- iTerm2: two Dynamic Profiles inherit the existing Default and tmux profiles and
+  override the font to MesloLGSNF-Regular 14. The Default-inheriting profile is
+  set as the default bookmark (targets.darwin.defaults). Dynamic profiles are
+  read on launch and immune to iTerm rewriting its own prefs on quit.
+- Terminal.app: the Homebrew profile's NSFont blob is set via a cfprefsd-safe
+  defaults export -> plutil -replace -> defaults import activation.
+
+Removes the stale, ignored com.googlecode.iterm2 font keys from
+nix/darwin/defaults.nix (superseded; avoids two layers writing the domain).
+EOF
+)"
+```
+
+Sandbox disable for gpg. No Claude attribution.
+
+- [ ] **Step 13: Verify commit + pre-flight diff**
+
+```bash
+git log --oneline -1
+git show --stat HEAD
+```
+
+Expected: one feat commit; stat shows new terminal-fonts.nix, modified default.nix + defaults.nix.
+
+---
+
+## Task 2: Update `nix/README.md`
+
+**Files:** Modify `nix/README.md`.
+
+- [ ] **Step 1:** `grep -n "For the nix-homedir slice" nix/README.md`; insert the new block after the nix-homedir sub-block, before the closing "The same shape applies to future slices" paragraph.
+- [ ] **Step 2:** Insert the spec's "For the nix-terminal-fonts slice" block verbatim (paragraph-heading style, no `###`).
+- [ ] **Step 3:** Verify `grep -nE "^For the nix-terminal-fonts slice" nix/README.md` → one paragraph-form match.
+- [ ] **Step 4:** Commit `git add nix/README.md && git commit -m "docs(nix): document nix-terminal-fonts slice migration"` (sandbox disable for gpg).
+- [ ] **Step 5:** Verify `git log --oneline -3`.
+
+---
+
+## Task 3: Cross-slice verification
+
+- [ ] **Step 1:** Clean reapply if needed (user-run, Terminal.app quit): inspect for warnings.
+- [ ] **Step 2:** Re-confirm the eval/defaults invariants (Task 1 Steps 9-10): dynamic profile file, Default Bookmark Guid, Terminal blob decodes to MesloLGSNF-Regular.
+- [ ] **Step 3:** **User visual confirmation** (the actual payoff): iTerm Default window renders the Nerd Font + starship glyph; `tmux (nix)` profile renders it; Terminal.app Homebrew profile renders it after quit+reopen. Record results; if any fails, capture the actual `defaults read` value and diagnose (likely font-name nuance → regen blob via the documented Swift snippet, or dynamic-profile key casing).
+- [ ] **Step 4:** Confirm `nix/darwin/defaults.nix` no longer references iTerm; no other domains lost.
+- [ ] **Step 5:** Confirm commit shape: `git log --oneline nix-homedir..HEAD` → spec + feat + docs.
+- [ ] **Step 6:** Update `docs/superpowers/nix-migration-status.md` (LOCAL ONLY): mark the iTerm/Terminal font deferral CLOSED by slice 16 (nix-terminal-fonts); note the Terminal-quit-first caveat.
+- [ ] **Step 7:** Open PR (gated on explicit user approval — memory `ask-before-merging`). `git push -u origin nix-terminal-fonts`; `gh pr create --base nix-homedir --title "feat(nix): render Nerd Font in iTerm2 + Terminal.app" --body "..."`.
+
+---
+
+## Self-review against the spec
+
+- Decision 1 (iTerm dynamic profiles, both): Step 3 (`iterm2DynamicProfiles`, two profiles).
+- Decision 2 (MesloLGSNF-Regular 14): the `font` binding.
+- Decision 3 (auto-activate via Default Bookmark Guid): `targets.darwin.defaults`.
+- Decision 4 (Terminal.app blob via export/plutil/import): `home.activation.terminalAppFont`.
+- Decision 5 (stored blob + regen comment): the `terminalFontBlob` string.
+- Decision 6 (remove stale iTerm block from defaults.nix): Step 5.
+- Decision 7 (default profile, isDarwin-gated): `lib.mkIf pkgs.stdenv.isDarwin` + import in default.nix.
+- Decision 8/9 (fonts only, non-sensitive): scope.
+
+Placeholder scan: exact commands/code throughout (the module content is copied from the spec verbatim). Type consistency: `font`, `defaultGuid`, `tmuxGuid`, `terminalFontBlob`, `iterm2DynamicProfiles`, `terminalAppFont` consistent.
+
+## Cross-references
+
+- Design spec: `docs/superpowers/specs/2026-05-28-nix-terminal-fonts-design.md`
+- Prior slice plan: `docs/superpowers/plans/2026-05-27-nix-homedir.md`

--- a/docs/superpowers/specs/2026-05-28-nix-terminal-fonts-design.md
+++ b/docs/superpowers/specs/2026-05-28-nix-terminal-fonts-design.md
@@ -1,42 +1,54 @@
 # Nix Terminal Fonts Slice Design
 
 **Date:** 2026-05-28
-**Status:** Draft — pending user approval
+**Status:** Implemented (pivoted from dynamic profiles to in-place patching — see Decision 1)
 **Branch:** `nix-terminal-fonts` (stacks on `nix-homedir` / PR #75 → `nix-vscode` / PR #74 → … → master)
 
 ## Goal
 
-Close the long-deferred terminal-font deferral (originally deferral #4, reopened after the nix-firstrun slice's plain-string attempt was found not to work). Make iTerm2 and Terminal.app actually render the MesloLGS Nerd Font so starship's git-branch/powerline glyphs display correctly — declaratively, via home-manager.
+Close the long-deferred terminal-font deferral (originally deferral #4, reopened after the nix-firstrun slice's plain-string attempt was found not to work). Make iTerm2 and Terminal.app actually render the MesloLGS Nerd Font so starship's git-branch/powerline glyphs display correctly — declaratively, via home-manager, on the user's **existing** profiles.
 
 ## Background — why the firstrun attempt failed
 
-The nix-firstrun slice wrote `CustomUserPreferences."com.googlecode.iterm2"."Normal Font" = "MesloLGS-NF-Regular 14"` as a **top-level** default. Investigation for this slice found two reasons it never worked:
+The nix-firstrun slice wrote `CustomUserPreferences."com.googlecode.iterm2"."Normal Font" = "MesloLGS-NF-Regular 14"` as a **top-level** default. Two reasons it never worked:
 
-1. **Wrong key location.** iTerm's font is not a top-level pref — it lives per-profile inside the `New Bookmarks` array. The user's actual profiles ("Default" GUID `BC395EC2-…`, and "tmux" GUID `B419BC64-…`) were both set to `Monaco 20`. The top-level `Normal Font` key was simply ignored.
-2. **Wrong font name.** The installed Nerd Font's real PostScript names are `MesloLGSNF-Regular` ("MesloLGS Nerd Font") and `MesloLGSNFM-Regular` (the Mono variant) — not `MesloLGS-NF-Regular`. The correct iTerm font value is `MesloLGSNF-Regular 14`.
+1. **Wrong key location.** iTerm's font is per-profile, inside the `New Bookmarks` array — not a top-level pref. The user's profiles ("Default" GUID `BC395EC2-…`, "tmux" GUID `B419BC64-…`) were both `Monaco 20`; the top-level key was ignored.
+2. **Wrong font name.** The installed Nerd Font's real PostScript names are `MesloLGSNF-Regular` ("MesloLGS Nerd Font") / `MesloLGSNFM-Regular` (Mono) — not `MesloLGS-NF-Regular`. The correct value is `MesloLGSNF-Regular 14`.
 
-Terminal.app stores its font as a binary NSFont blob (NSKeyedArchiver) inside the per-profile dict (the user's default/startup profile is "Homebrew"), which is why no plain-string write reaches it either.
+Terminal.app stores its font as a binary NSFont blob (NSKeyedArchiver) in the per-profile dict (the user's default/startup profile is "Homebrew").
+
+The font itself is already installed and registered — via the `font-meslo-lg-nerd-font` cask (slice 10), present in `~/Library/Fonts/` and discoverable by CoreText. This slice does NOT install fonts; it only sets the per-profile font preference.
+
+## Decision 1 — mechanism (pivoted)
+
+**Patch the font onto the EXISTING profiles in place, not via dynamic profiles.**
+
+The slice was first designed around iTerm Dynamic Profiles (parallel profiles inheriting Default/tmux, with the default-bookmark GUID repointed). That was abandoned during implementation because it created *parallel* profiles that don't automatically take over the default/tmux roles:
+
+- The `Default Bookmark Guid` pref (needed to auto-activate the dynamic Default profile) lives in iTerm's own plist, which a **running iTerm rewrites on quit** — so the repoint got clobbered.
+- The "tmux" profile is **not GUID-pinned anywhere** in iTerm's prefs (verified), so a parallel `tmux (nix)` profile can't be made the one iTerm uses without manual selection.
+
+Both problems vanish if we patch the **existing** Default and tmux profiles directly: they remain the default / the tmux profile (whatever selects them still does), now rendering the Nerd Font. A running app still clobbers any pref write, so the unavoidable constraint — **quit iTerm and Terminal.app during `./apply`** — applies to either mechanism; in-place is simply the one that satisfies the goal.
 
 ## Decisions (locked)
 
-1. **iTerm via Dynamic Profiles (clobber-immune), both profiles.** home-manager writes `~/Library/Application Support/iTerm2/DynamicProfiles/nix.json` defining two profiles, each using `"Dynamic Profile Parent Name"` to inherit an existing profile and override only the font:
-   - **`Default (nix)`** — GUID `95362E86-C10E-48E3-9FA1-DC4596B0F677`, parent `"Default"`.
-   - **`tmux (nix)`** — GUID `BF5B17AC-8CB2-4C36-942E-F45E91EAF11A`, parent `"tmux"`.
-   Dynamic profiles are read fresh on iTerm launch and are NOT part of the plist iTerm rewrites on quit, so they can't be clobbered by a running iTerm (the deciding advantage over patching `New Bookmarks` in place).
-2. **Font: `MesloLGSNF-Regular 14`** ("MesloLGS Nerd Font", non-Mono — the starship/powerlevel10k-recommended variant; allows double-width icon glyphs). Set as both `"Normal Font"` and `"Non Ascii Font"`, with `"Use Non-ASCII Font" = false` (use the normal font for non-ASCII too).
-3. **Auto-activate the Default-inheriting profile.** Set `targets.darwin.defaults."com.googlecode.iterm2"."Default Bookmark Guid" = "95362E86-…"` so `Default (nix)` becomes the active default. The `tmux (nix)` profile is selected manually for tmux windows once (tmux isn't GUID-pinned anywhere in the user's prefs — verified — so there's nothing to repoint automatically).
-4. **Terminal.app via a stored NSFont blob injected by activation.** Terminal has no dynamic-profiles equivalent. A `home.activation` injects a precomputed NSKeyedArchiver NSFont blob for `MesloLGSNF-Regular` size 14 into the "Homebrew" profile's `Font` key, using a cfprefsd-safe round-trip: `defaults export` → `plutil -replace 'Window Settings.Homebrew.Font' -data <base64>` → `defaults import`.
-5. **Store the precomputed blob (with a regen comment), don't generate at activation.** The 273-byte base64 blob is committed as a Nix string with a comment documenting the Swift one-liner to regenerate it. Rationale: avoids a hard Xcode-CLT dependency and a multi-second `swift` compile on every `./apply`; the NSFont archive format is stable in practice. (Generating in a nix derivation isn't possible — swift needs the macOS SDK, unavailable in the nix build sandbox.)
-6. **Remove the stale iTerm block from `nix/darwin/defaults.nix`.** The firstrun slice's `CustomUserPreferences."com.googlecode.iterm2"` font keys are ignored cruft and now superseded. Removing them also avoids two layers (nix-darwin + home-manager `targets.darwin.defaults`) writing the same `com.googlecode.iterm2` domain.
-7. **Profile: `default`, darwin-gated.** iTerm/Terminal are macOS GUI apps; the module lives in the `default` (personal-macOS) profile and is wrapped in `lib.mkIf pkgs.stdenv.isDarwin` so the `default@*-linux` matrix build is a no-op.
-8. **No content beyond fonts.** This slice only sets fonts. It does not manage colors, keybindings, or other iTerm/Terminal settings (the dynamic profiles inherit everything else from their parents).
-9. **No work-specific values.** The blob is a non-sensitive NSFont archive (font name + size); fine for the public `default` profile.
+1. **In-place patch of existing profiles** (see Decision 1 above), via a single Python `plistlib` round-trip: `defaults export <domain> → modify → defaults import <domain>`. The round-trip writes through cfprefsd cleanly (no `killall cfprefsd` needed). Profiles are matched **by name** (order- and count-independent; leaves other profiles untouched).
+2. **Font: `MesloLGSNF-Regular 14`** ("MesloLGS Nerd Font", non-Mono — the powerlevel10k/starship-recommended variant, tuned for these prompts; iTerm renders its double-width icon glyphs fine). Set as both `"Normal Font"` and `"Non Ascii Font"`. (The Mono variant `MesloLGSNFM-Regular` is the safer generic-terminal default; non-Mono is the documented pick for this user's starship prompt.)
+3. **iTerm: patch profiles named "Default" and "tmux"** in `com.googlecode.iterm2` `New Bookmarks`. No new profiles, no `Default Bookmark Guid` change (the existing Default profile stays the default), no tmux re-selection.
+4. **Terminal.app: set the "Homebrew" profile's `Font`** in `com.apple.Terminal` `Window Settings` to a precomputed NSKeyedArchiver NSFont blob (bytes → `<data>`), creating the key if absent (it was). Same `plistlib` round-trip as iTerm.
+5. **Store the precomputed blob (with a regen comment), don't generate at activation.** The 273-byte base64 blob is a Nix string with a comment documenting the Swift one-liner to regenerate. Avoids a hard Xcode-CLT dependency and per-apply `swift` cost; the NSFont archive format is stable. (Can't generate in a nix derivation — swift needs the macOS SDK, unavailable in the build sandbox.)
+6. **Remove the stale iTerm block from `nix/darwin/defaults.nix`.** The firstrun slice's `CustomUserPreferences."com.googlecode.iterm2"` font keys are ignored cruft and now superseded.
+7. **Profile: `default`, darwin-gated.** iTerm/Terminal are macOS GUI apps; the module is in the `default` (personal-macOS) profile, wrapped in `lib.mkIf pkgs.stdenv.isDarwin` so the `default@*-linux` matrix build is a no-op.
+8. **Fonts only.** No colors/keybindings/other settings — the existing profiles keep everything else.
+9. **No font installation.** The Nerd Font is already installed via the slice-10 cask; this slice only sets the per-profile font preference (no `pkgs.nerd-fonts.*`, no `fonts.fontconfig`).
+10. **No work-specific values.** The blob is a non-sensitive NSFont archive (name + size).
 
 ## Architecture
 
 ```text
 NEW FILES:
-  nix/profiles/default/terminal-fonts.nix          # iTerm dynamic profiles + Default Bookmark Guid + Terminal.app activation
+  nix/profiles/default/terminal-fonts.nix          # darwin-gated module: the patch activation + font/blob lets
+  nix/profiles/default/patch-terminal-fonts.py     # plistlib patcher (iTerm Default/tmux + Terminal Homebrew)
 
 MODIFIED FILES:
   nix/profiles/default/default.nix                 # imports ./terminal-fonts.nix
@@ -44,9 +56,9 @@ MODIFIED FILES:
   nix/README.md                                    # +migration guide sub-block
 
 UNTOUCHED:
-  ~/Library/Preferences/com.googlecode.iterm2.plist  # iTerm's own prefs — never edited (dynamic profiles are separate)
-  the existing "Default"/"tmux" iTerm profiles        # kept as dynamic-profile parents
-  ~/Library/Preferences/com.apple.Terminal.plist      # only the Homebrew profile's Font key is touched, via export/import round-trip
+  font installation                                # already via the font-meslo-lg-nerd-font cask (slice 10)
+  iTerm/Terminal profiles other than the font key  # patched in place, everything else preserved
+  Default Bookmark Guid                            # existing Default profile stays the default
 ```
 
 ## `nix/profiles/default/terminal-fonts.nix` (full content)
@@ -56,150 +68,99 @@ UNTOUCHED:
 let
   font = "MesloLGSNF-Regular 14";   # "MesloLGS Nerd Font" 14pt; PostScript name + size
 
-  defaultGuid = "95362E86-C10E-48E3-9FA1-DC4596B0F677";
-  tmuxGuid    = "BF5B17AC-8CB2-4C36-942E-F45E91EAF11A";
-
   # NSKeyedArchiver-encoded NSFont for "MesloLGSNF-Regular" at 14pt, base64.
   # Terminal.app stores profile fonts as this binary blob. Regenerate with:
   #   swift -e 'import AppKit; let f = NSFont(name: "MesloLGSNF-Regular", size: 14)!; print(try! NSKeyedArchiver.archivedData(withRootObject: f, requiringSecureCoding: false).base64EncodedString())'
   terminalFontBlob =
     "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGkCwwVFlUkbnVsbNQNDg8QERITFFZOU1NpemVYTlNmRmxhZ3NWTlNOYW1lViRjbGFzcyNALAAAAAAAABAQgAKAA18QEk1lc2xvTEdTTkYtUmVndWxhctIXGBkaWiRjbGFzc25hbWVYJGNsYXNzZXNWTlNGb250ohkbWE5TT2JqZWN0CBEaJCkyN0lMUVNYXmdud36FjpCSlKmuucLJzAAAAAAAAAEBAAAAAAAAABwAAAAAAAAAAAAAAAAAAADV";
-
-  iterm2DynamicProfiles = {
-    Profiles = [
-      {
-        Name = "Default (nix)";
-        Guid = defaultGuid;
-        "Dynamic Profile Parent Name" = "Default";
-        "Normal Font" = font;
-        "Non Ascii Font" = font;
-        "Use Non-ASCII Font" = false;
-      }
-      {
-        Name = "tmux (nix)";
-        Guid = tmuxGuid;
-        "Dynamic Profile Parent Name" = "tmux";
-        "Normal Font" = font;
-        "Non Ascii Font" = font;
-        "Use Non-ASCII Font" = false;
-      }
-    ];
-  };
 in
 lib.mkIf pkgs.stdenv.isDarwin {
-  # iTerm: dynamic profiles (read on launch; immune to iTerm rewriting its own
-  # prefs plist on quit). The Default-inheriting one is set as the default
-  # bookmark below so it auto-activates; the tmux one is selected manually for
-  # tmux windows (tmux is not GUID-pinned anywhere in iTerm's prefs).
-  home.file."Library/Application Support/iTerm2/DynamicProfiles/nix.json".text =
-    builtins.toJSON iterm2DynamicProfiles;
-
-  targets.darwin.defaults."com.googlecode.iterm2"."Default Bookmark Guid" = defaultGuid;
-
-  # Terminal.app: no dynamic-profiles equivalent. Inject the NSFont blob into
-  # the "Homebrew" profile (the user's default/startup profile) via a
-  # cfprefsd-safe export -> plutil -replace -> import round-trip. Idempotent.
-  # NOTE: if Terminal.app is running during ./apply it may rewrite its prefs on
-  # quit and revert this; quit Terminal.app before applying for it to stick.
-  home.activation.terminalAppFont =
+  # Patch the font onto the EXISTING iTerm "Default"/"tmux" profiles and
+  # Terminal.app's "Homebrew" profile in place. A Python plistlib
+  # `defaults export -> modify -> defaults import` round-trip writes through
+  # cfprefsd cleanly and matches profiles by name (order/count-independent).
+  #
+  # CONSTRAINT: iTerm and Terminal.app must be QUIT during ./apply — both
+  # rewrite their prefs on quit and would otherwise revert these changes.
+  # Idempotent: re-running sets the same values.
+  home.activation.terminalFonts =
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      tmp="$(/usr/bin/mktemp)"
-      if /usr/bin/defaults export com.apple.Terminal "$tmp" 2>/dev/null \
-         && /usr/bin/plutil -replace 'Window Settings.Homebrew.Font' \
-              -data '${terminalFontBlob}' "$tmp" 2>/dev/null; then
-        /usr/bin/defaults import com.apple.Terminal "$tmp"
-      fi
-      /bin/rm -f "$tmp"
+      ${pkgs.python3}/bin/python3 ${./patch-terminal-fonts.py} \
+        ${lib.escapeShellArg font} ${lib.escapeShellArg terminalFontBlob} || true
     '';
 }
 ```
 
-Notes:
-- `builtins.toJSON` is fine for the dynamic-profile file — iTerm reads JSON dynamic profiles.
-- `"Use Non-ASCII Font" = false` means iTerm uses `Normal Font` for non-ASCII glyphs too; we still set `Non Ascii Font` to the same value for completeness.
-- The activation guards on `defaults export` + `plutil` succeeding before `import`, so a missing "Homebrew" profile or export failure won't corrupt anything (it just skips). It runs `entryAfter [ "writeBoundary" ]` (standard for non-link activations that mutate external state).
-- `plutil -replace` keypath `'Window Settings.Homebrew.Font'`: `.` separates levels; "Window Settings" (with a space) is a single key — plutil handles spaces in keys.
+## `nix/profiles/default/patch-terminal-fonts.py`
+
+A small Python 3 patcher (full source in the file). It:
+- Round-trips each domain via `defaults export` → `plistlib.load` → mutate → `plistlib.dump` → `defaults import`.
+- **iTerm** (`com.googlecode.iterm2`): for every `New Bookmarks` profile whose `Name` is `"Default"` or `"tmux"`, sets `Normal Font` and `Non Ascii Font` to the font string.
+- **Terminal** (`com.apple.Terminal`): sets `Window Settings → Homebrew → Font` to `base64.b64decode(blob)` (bytes → `<data>`), creating the key.
+- Takes `<font>` and `<terminal-blob-base64>` as argv (passed from the module via `lib.escapeShellArg`).
 
 ## `nix/profiles/default/default.nix` change
 
-Add `./terminal-fonts.nix` to imports:
-
-```nix
-  imports = [
-    ./claude.nix
-    ./cli-tools.nix
-    ./terminal-fonts.nix
-  ];
-```
+Add `./terminal-fonts.nix` to imports (alphabetical, after `./cli-tools.nix`).
 
 ## `nix/darwin/defaults.nix` change
 
-Remove the `# ----- iTerm 2 -----` block under `CustomUserPreferences` (the `"com.googlecode.iterm2" = { "Normal Font" = …; "Non Ascii Font" = …; "Use Non-ASCII Font" = …; };` entry added by nix-firstrun). It is ignored by iTerm and now superseded. Leave all other `CustomUserPreferences` domains intact.
+Remove the `# ----- iTerm 2 -----` block + the `"com.googlecode.iterm2" = { … };` entry under `CustomUserPreferences`. Leave all other domains intact.
 
 ## Migration guide block in `nix/README.md`
-
-Append after the "For the nix-homedir slice" sub-block, paragraph-heading style:
 
 ```markdown
 For the nix-terminal-fonts slice (iTerm2 + Terminal.app Nerd Font, declarative):
 
 Closes the terminal-font deferral. The nix-firstrun attempt wrote a top-level
-`Normal Font` pref, which iTerm ignores (the font lives per-profile in
-`New Bookmarks`), with a typo'd PostScript name. This slice does it correctly:
+`Normal Font` pref (ignored — the font lives per-profile) with a typo'd
+PostScript name. This slice patches the font onto your EXISTING profiles in
+place via a Python plistlib `defaults export → modify → import` round-trip
+(`nix/profiles/default/patch-terminal-fonts.py`, run from a home-manager
+activation):
 
-- **iTerm2** — two Dynamic Profiles (`~/Library/Application Support/iTerm2/DynamicProfiles/nix.json`)
-  inherit your existing `Default` and `tmux` profiles and override the font to
-  `MesloLGSNF-Regular 14` ("MesloLGS Nerd Font"). The Default-inheriting profile
-  (`Default (nix)`) is set as iTerm's default bookmark, so it auto-activates;
-  relaunch iTerm to see it. For tmux windows, select the `tmux (nix)` profile
-  once. Dynamic profiles can't be clobbered by iTerm rewriting its own prefs.
-- **Terminal.app** — the "Homebrew" profile's font (a binary NSFont blob) is set
-  via a `defaults export → plutil -replace → defaults import` round-trip in a
-  home-manager activation. **Quit Terminal.app before `./apply`** for the change
-  to stick (Terminal rewrites its prefs on quit and has no dynamic-profiles
-  escape hatch). You use iTerm as the daily driver, so this is low-impact.
+- **iTerm2** — the `Default` and `tmux` profiles get `Normal Font` /
+  `Non Ascii Font` set to `MesloLGSNF-Regular 14` ("MesloLGS Nerd Font").
+- **Terminal.app** — the `Homebrew` profile's `Font` (a binary NSFont blob,
+  generated once via Swift and stored with a regen comment) is set.
 
-**Changing the font:** edit `font` in `nix/profiles/default/terminal-fonts.nix`
-and `./apply`. For Terminal.app, also regenerate the NSFont blob (the Swift
-one-liner is in the file's comment) since Terminal needs the binary archive.
+**CONSTRAINT: quit iTerm2 and Terminal.app before `./apply`.** Both rewrite
+their prefs on quit, so a running app reverts the change. Relaunch them after
+applying to see the font. The patch is idempotent.
 
-**Private flake update (only if you have one):** if your private flake adds
-iTerm dynamic profiles or `targets.darwin.defaults` for these domains, Nix
-module merging handles additive entries; conflicting keys need `lib.mkForce`.
+**Changing the font:** edit `font` in `nix/profiles/default/terminal-fonts.nix`.
+For Terminal.app, also regenerate the NSFont blob (the Swift one-liner is in the
+file's comment). The font itself is installed by the `font-meslo-lg-nerd-font`
+cask (nix-darwin slice), not here.
+
+**Private flake update (only if you have one):** if your private flake also
+patches these domains, be aware both run on activation; last writer wins per key.
 ```
-
-## Open questions resolved during plan / implementation
-
-1. **`plutil -replace` keypath with the space in "Window Settings".** Verify `plutil -replace 'Window Settings.Homebrew.Font' -data <b64> <file>` targets the right nested key (it should — `.` is the level separator, spaces are literal). If plutil mis-parses, fall back to a Python `plistlib` round-trip (load exported plist, set `pl["Window Settings"]["Homebrew"]["Font"] = base64.b64decode(blob)`, write, import).
-2. **`targets.darwin.defaults` option name/shape.** Confirm the home-manager option is `targets.darwin.defaults.<domain>.<key>` at this pin (the `modules/targets/darwin/user-defaults` module exists). If the path differs, set the `Default Bookmark Guid` via a small `home.activation` `defaults write` instead.
-3. **Dynamic profile "Use Non-ASCII Font" key name.** Confirm iTerm reads `"Use Non-ASCII Font"` (boolean) and `"Non Ascii Font"` (string) from dynamic-profile JSON the same as from the main plist. If the JSON expects different casing, adjust.
-4. **Terminal blob validity at apply.** After apply (Terminal quit), open Terminal → the Homebrew profile shows MesloLGS Nerd Font 14. If the blob doesn't take, regenerate via the documented Swift snippet on the actual machine (handles any local font-name nuance).
 
 ## Testing
 
-Per project convention (no automated tests), manual verification in the plan:
+Verification performed (all passed):
 
-1. **Pre-flight:** capture `defaults read com.googlecode.iterm2 "New Bookmarks"` font values (Monaco 20) and `defaults read com.apple.Terminal "Window Settings.Homebrew.Font"` (current blob); confirm DynamicProfiles dir empty.
-2. **Eval gates (pre-apply):** the module evals; `home.file."Library/Application Support/iTerm2/DynamicProfiles/nix.json"` is present; `targets.darwin.defaults` resolves; `nix/darwin/defaults.nix` no longer references `com.googlecode.iterm2`; agent@linux build is a no-op (isDarwin guard).
-3. **After `./apply`:**
-   - `~/Library/Application Support/iTerm2/DynamicProfiles/nix.json` exists (symlink), contains the two profiles with `MesloLGSNF-Regular 14`.
-   - `defaults read com.googlecode.iterm2 "Default Bookmark Guid"` → `95362E86-…`.
-   - `defaults read com.apple.Terminal "Window Settings.Homebrew.Font"` → a blob decoding to MesloLGSNF-Regular 14 (compare to the source blob, or `plutil -p`).
-   - **Manual visual:** relaunch iTerm → Default window uses MesloLGS Nerd Font; starship branch glyph renders (no missing-glyph box). Select `tmux (nix)` → tmux windows use it. Quit+reopen Terminal.app → Homebrew profile uses it.
-4. **Idempotence:** second `./apply` — dynamic-profile file unchanged; the Terminal activation re-injects the same blob (no-op effect).
+1. Pre-apply: iTerm Default/tmux at `Monaco 20`; Terminal Homebrew had no `Font` key.
+2. Eval gates: `home.activation.terminalFonts` references the patcher; no DynamicProfiles `home.file`; Python syntax valid; full home-manager build evals; `default@x86_64-linux` is a no-op (isDarwin guard).
+3. After `./apply` (iTerm + Terminal quit):
+   - iTerm `New Bookmarks` "Default" and "tmux" both → `Normal Font` / `Non Ascii Font` = `MesloLGSNF-Regular 14`. Exactly 2 such profiles (no leftover `(nix)` duplicates from the earlier dynamic-profile attempt).
+   - Terminal `Window Settings.Homebrew.Font` present, 273 bytes, decodes to contain `MesloLGSNF-Regular`.
+   - The old `~/Library/Application Support/iTerm2/DynamicProfiles/nix.json` symlink removed (orphan cleanup).
+   - **Visual (user-confirmed):** glyphs render correctly in iTerm + Terminal.
+4. Idempotence: re-running sets the same values (matched by name).
 
 ## Risk and rollback
 
-**Risk profile:** Low-medium. iTerm side is low-risk (dynamic profiles are additive, non-destructive, separate file). Terminal side is the riskier part: the `defaults import` replaces the com.apple.Terminal domain from the exported+modified copy (preserves everything else; tiny race only if Terminal writes between export and import — mitigated by quit-first guidance). The stored blob is opaque but documented/regenerable.
+**Risk:** Low. Each domain is round-tripped via `defaults export`/`import` (cfprefsd-safe). The patcher guards on export succeeding and on the expected structure existing before mutating, and only touches the font keys (iTerm) / the Homebrew Font key (Terminal). The clobber risk (running app reverts on quit) is mitigated by the quit-first constraint and idempotent re-apply.
 
-**Rollback:** `git revert` the slice + `./apply`. The iTerm dynamic-profile file is removed (iTerm reverts to the original Default/tmux profiles automatically); `Default Bookmark Guid` reverts. For Terminal, the activation stops running; the last-imported font persists until manually changed (re-set the Homebrew profile font by hand if reverting fully). No data loss — iTerm's own profiles were never edited.
+**Rollback:** `git revert` the slice; re-`./apply` (the activation stops running). The last-set font persists until manually changed; reset the profile fonts by hand if reverting fully. No data loss — only font keys are touched.
 
 ## Out of scope
 
-- **Other iTerm/Terminal settings** (colors, keybindings, window size) — fonts only.
-- **The "tmux" iTerm integration auto-pointing at the new profile** — tmux isn't GUID-pinned, so the user selects `tmux (nix)` manually; not worth special machinery.
-- **Generating the NSFont blob at activation time** — rejected (Xcode-CLT dependency + per-apply swift cost); stored blob with regen comment instead.
-- **Other terminal emulators** (Alacritty, kitty, etc.) — not installed/used.
+- Other iTerm/Terminal settings (colors, keybindings); other terminal emulators.
+- Font installation (already via the cask).
+- Full declarative iTerm config (the "custom prefs folder" / whole-plist approach) — would replace the user's entire config; this slice is font-only.
 
 ## Cross-references
 
@@ -207,3 +168,4 @@ Per project convention (no automated tests), manual verification in the plan:
 - nix-firstrun slice (the original font attempt): `docs/superpowers/specs/2026-05-26-nix-firstrun-design.md`
 - Status doc (local, uncommitted): `docs/superpowers/nix-migration-status.md` — closes the reopened iTerm/Terminal font deferral
 - Migration guide: `nix/README.md`
+```

--- a/docs/superpowers/specs/2026-05-28-nix-terminal-fonts-design.md
+++ b/docs/superpowers/specs/2026-05-28-nix-terminal-fonts-design.md
@@ -1,0 +1,209 @@
+# Nix Terminal Fonts Slice Design
+
+**Date:** 2026-05-28
+**Status:** Draft — pending user approval
+**Branch:** `nix-terminal-fonts` (stacks on `nix-homedir` / PR #75 → `nix-vscode` / PR #74 → … → master)
+
+## Goal
+
+Close the long-deferred terminal-font deferral (originally deferral #4, reopened after the nix-firstrun slice's plain-string attempt was found not to work). Make iTerm2 and Terminal.app actually render the MesloLGS Nerd Font so starship's git-branch/powerline glyphs display correctly — declaratively, via home-manager.
+
+## Background — why the firstrun attempt failed
+
+The nix-firstrun slice wrote `CustomUserPreferences."com.googlecode.iterm2"."Normal Font" = "MesloLGS-NF-Regular 14"` as a **top-level** default. Investigation for this slice found two reasons it never worked:
+
+1. **Wrong key location.** iTerm's font is not a top-level pref — it lives per-profile inside the `New Bookmarks` array. The user's actual profiles ("Default" GUID `BC395EC2-…`, and "tmux" GUID `B419BC64-…`) were both set to `Monaco 20`. The top-level `Normal Font` key was simply ignored.
+2. **Wrong font name.** The installed Nerd Font's real PostScript names are `MesloLGSNF-Regular` ("MesloLGS Nerd Font") and `MesloLGSNFM-Regular` (the Mono variant) — not `MesloLGS-NF-Regular`. The correct iTerm font value is `MesloLGSNF-Regular 14`.
+
+Terminal.app stores its font as a binary NSFont blob (NSKeyedArchiver) inside the per-profile dict (the user's default/startup profile is "Homebrew"), which is why no plain-string write reaches it either.
+
+## Decisions (locked)
+
+1. **iTerm via Dynamic Profiles (clobber-immune), both profiles.** home-manager writes `~/Library/Application Support/iTerm2/DynamicProfiles/nix.json` defining two profiles, each using `"Dynamic Profile Parent Name"` to inherit an existing profile and override only the font:
+   - **`Default (nix)`** — GUID `95362E86-C10E-48E3-9FA1-DC4596B0F677`, parent `"Default"`.
+   - **`tmux (nix)`** — GUID `BF5B17AC-8CB2-4C36-942E-F45E91EAF11A`, parent `"tmux"`.
+   Dynamic profiles are read fresh on iTerm launch and are NOT part of the plist iTerm rewrites on quit, so they can't be clobbered by a running iTerm (the deciding advantage over patching `New Bookmarks` in place).
+2. **Font: `MesloLGSNF-Regular 14`** ("MesloLGS Nerd Font", non-Mono — the starship/powerlevel10k-recommended variant; allows double-width icon glyphs). Set as both `"Normal Font"` and `"Non Ascii Font"`, with `"Use Non-ASCII Font" = false` (use the normal font for non-ASCII too).
+3. **Auto-activate the Default-inheriting profile.** Set `targets.darwin.defaults."com.googlecode.iterm2"."Default Bookmark Guid" = "95362E86-…"` so `Default (nix)` becomes the active default. The `tmux (nix)` profile is selected manually for tmux windows once (tmux isn't GUID-pinned anywhere in the user's prefs — verified — so there's nothing to repoint automatically).
+4. **Terminal.app via a stored NSFont blob injected by activation.** Terminal has no dynamic-profiles equivalent. A `home.activation` injects a precomputed NSKeyedArchiver NSFont blob for `MesloLGSNF-Regular` size 14 into the "Homebrew" profile's `Font` key, using a cfprefsd-safe round-trip: `defaults export` → `plutil -replace 'Window Settings.Homebrew.Font' -data <base64>` → `defaults import`.
+5. **Store the precomputed blob (with a regen comment), don't generate at activation.** The 273-byte base64 blob is committed as a Nix string with a comment documenting the Swift one-liner to regenerate it. Rationale: avoids a hard Xcode-CLT dependency and a multi-second `swift` compile on every `./apply`; the NSFont archive format is stable in practice. (Generating in a nix derivation isn't possible — swift needs the macOS SDK, unavailable in the nix build sandbox.)
+6. **Remove the stale iTerm block from `nix/darwin/defaults.nix`.** The firstrun slice's `CustomUserPreferences."com.googlecode.iterm2"` font keys are ignored cruft and now superseded. Removing them also avoids two layers (nix-darwin + home-manager `targets.darwin.defaults`) writing the same `com.googlecode.iterm2` domain.
+7. **Profile: `default`, darwin-gated.** iTerm/Terminal are macOS GUI apps; the module lives in the `default` (personal-macOS) profile and is wrapped in `lib.mkIf pkgs.stdenv.isDarwin` so the `default@*-linux` matrix build is a no-op.
+8. **No content beyond fonts.** This slice only sets fonts. It does not manage colors, keybindings, or other iTerm/Terminal settings (the dynamic profiles inherit everything else from their parents).
+9. **No work-specific values.** The blob is a non-sensitive NSFont archive (font name + size); fine for the public `default` profile.
+
+## Architecture
+
+```text
+NEW FILES:
+  nix/profiles/default/terminal-fonts.nix          # iTerm dynamic profiles + Default Bookmark Guid + Terminal.app activation
+
+MODIFIED FILES:
+  nix/profiles/default/default.nix                 # imports ./terminal-fonts.nix
+  nix/darwin/defaults.nix                          # remove stale CustomUserPreferences."com.googlecode.iterm2" block
+  nix/README.md                                    # +migration guide sub-block
+
+UNTOUCHED:
+  ~/Library/Preferences/com.googlecode.iterm2.plist  # iTerm's own prefs — never edited (dynamic profiles are separate)
+  the existing "Default"/"tmux" iTerm profiles        # kept as dynamic-profile parents
+  ~/Library/Preferences/com.apple.Terminal.plist      # only the Homebrew profile's Font key is touched, via export/import round-trip
+```
+
+## `nix/profiles/default/terminal-fonts.nix` (full content)
+
+```nix
+{ pkgs, lib, ... }:
+let
+  font = "MesloLGSNF-Regular 14";   # "MesloLGS Nerd Font" 14pt; PostScript name + size
+
+  defaultGuid = "95362E86-C10E-48E3-9FA1-DC4596B0F677";
+  tmuxGuid    = "BF5B17AC-8CB2-4C36-942E-F45E91EAF11A";
+
+  # NSKeyedArchiver-encoded NSFont for "MesloLGSNF-Regular" at 14pt, base64.
+  # Terminal.app stores profile fonts as this binary blob. Regenerate with:
+  #   swift -e 'import AppKit; let f = NSFont(name: "MesloLGSNF-Regular", size: 14)!; print(try! NSKeyedArchiver.archivedData(withRootObject: f, requiringSecureCoding: false).base64EncodedString())'
+  terminalFontBlob =
+    "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGkCwwVFlUkbnVsbNQNDg8QERITFFZOU1NpemVYTlNmRmxhZ3NWTlNOYW1lViRjbGFzcyNALAAAAAAAABAQgAKAA18QEk1lc2xvTEdTTkYtUmVndWxhctIXGBkaWiRjbGFzc25hbWVYJGNsYXNzZXNWTlNGb250ohkbWE5TT2JqZWN0CBEaJCkyN0lMUVNYXmdud36FjpCSlKmuucLJzAAAAAAAAAEBAAAAAAAAABwAAAAAAAAAAAAAAAAAAADV";
+
+  iterm2DynamicProfiles = {
+    Profiles = [
+      {
+        Name = "Default (nix)";
+        Guid = defaultGuid;
+        "Dynamic Profile Parent Name" = "Default";
+        "Normal Font" = font;
+        "Non Ascii Font" = font;
+        "Use Non-ASCII Font" = false;
+      }
+      {
+        Name = "tmux (nix)";
+        Guid = tmuxGuid;
+        "Dynamic Profile Parent Name" = "tmux";
+        "Normal Font" = font;
+        "Non Ascii Font" = font;
+        "Use Non-ASCII Font" = false;
+      }
+    ];
+  };
+in
+lib.mkIf pkgs.stdenv.isDarwin {
+  # iTerm: dynamic profiles (read on launch; immune to iTerm rewriting its own
+  # prefs plist on quit). The Default-inheriting one is set as the default
+  # bookmark below so it auto-activates; the tmux one is selected manually for
+  # tmux windows (tmux is not GUID-pinned anywhere in iTerm's prefs).
+  home.file."Library/Application Support/iTerm2/DynamicProfiles/nix.json".text =
+    builtins.toJSON iterm2DynamicProfiles;
+
+  targets.darwin.defaults."com.googlecode.iterm2"."Default Bookmark Guid" = defaultGuid;
+
+  # Terminal.app: no dynamic-profiles equivalent. Inject the NSFont blob into
+  # the "Homebrew" profile (the user's default/startup profile) via a
+  # cfprefsd-safe export -> plutil -replace -> import round-trip. Idempotent.
+  # NOTE: if Terminal.app is running during ./apply it may rewrite its prefs on
+  # quit and revert this; quit Terminal.app before applying for it to stick.
+  home.activation.terminalAppFont =
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      tmp="$(/usr/bin/mktemp)"
+      if /usr/bin/defaults export com.apple.Terminal "$tmp" 2>/dev/null \
+         && /usr/bin/plutil -replace 'Window Settings.Homebrew.Font' \
+              -data '${terminalFontBlob}' "$tmp" 2>/dev/null; then
+        /usr/bin/defaults import com.apple.Terminal "$tmp"
+      fi
+      /bin/rm -f "$tmp"
+    '';
+}
+```
+
+Notes:
+- `builtins.toJSON` is fine for the dynamic-profile file — iTerm reads JSON dynamic profiles.
+- `"Use Non-ASCII Font" = false` means iTerm uses `Normal Font` for non-ASCII glyphs too; we still set `Non Ascii Font` to the same value for completeness.
+- The activation guards on `defaults export` + `plutil` succeeding before `import`, so a missing "Homebrew" profile or export failure won't corrupt anything (it just skips). It runs `entryAfter [ "writeBoundary" ]` (standard for non-link activations that mutate external state).
+- `plutil -replace` keypath `'Window Settings.Homebrew.Font'`: `.` separates levels; "Window Settings" (with a space) is a single key — plutil handles spaces in keys.
+
+## `nix/profiles/default/default.nix` change
+
+Add `./terminal-fonts.nix` to imports:
+
+```nix
+  imports = [
+    ./claude.nix
+    ./cli-tools.nix
+    ./terminal-fonts.nix
+  ];
+```
+
+## `nix/darwin/defaults.nix` change
+
+Remove the `# ----- iTerm 2 -----` block under `CustomUserPreferences` (the `"com.googlecode.iterm2" = { "Normal Font" = …; "Non Ascii Font" = …; "Use Non-ASCII Font" = …; };` entry added by nix-firstrun). It is ignored by iTerm and now superseded. Leave all other `CustomUserPreferences` domains intact.
+
+## Migration guide block in `nix/README.md`
+
+Append after the "For the nix-homedir slice" sub-block, paragraph-heading style:
+
+```markdown
+For the nix-terminal-fonts slice (iTerm2 + Terminal.app Nerd Font, declarative):
+
+Closes the terminal-font deferral. The nix-firstrun attempt wrote a top-level
+`Normal Font` pref, which iTerm ignores (the font lives per-profile in
+`New Bookmarks`), with a typo'd PostScript name. This slice does it correctly:
+
+- **iTerm2** — two Dynamic Profiles (`~/Library/Application Support/iTerm2/DynamicProfiles/nix.json`)
+  inherit your existing `Default` and `tmux` profiles and override the font to
+  `MesloLGSNF-Regular 14` ("MesloLGS Nerd Font"). The Default-inheriting profile
+  (`Default (nix)`) is set as iTerm's default bookmark, so it auto-activates;
+  relaunch iTerm to see it. For tmux windows, select the `tmux (nix)` profile
+  once. Dynamic profiles can't be clobbered by iTerm rewriting its own prefs.
+- **Terminal.app** — the "Homebrew" profile's font (a binary NSFont blob) is set
+  via a `defaults export → plutil -replace → defaults import` round-trip in a
+  home-manager activation. **Quit Terminal.app before `./apply`** for the change
+  to stick (Terminal rewrites its prefs on quit and has no dynamic-profiles
+  escape hatch). You use iTerm as the daily driver, so this is low-impact.
+
+**Changing the font:** edit `font` in `nix/profiles/default/terminal-fonts.nix`
+and `./apply`. For Terminal.app, also regenerate the NSFont blob (the Swift
+one-liner is in the file's comment) since Terminal needs the binary archive.
+
+**Private flake update (only if you have one):** if your private flake adds
+iTerm dynamic profiles or `targets.darwin.defaults` for these domains, Nix
+module merging handles additive entries; conflicting keys need `lib.mkForce`.
+```
+
+## Open questions resolved during plan / implementation
+
+1. **`plutil -replace` keypath with the space in "Window Settings".** Verify `plutil -replace 'Window Settings.Homebrew.Font' -data <b64> <file>` targets the right nested key (it should — `.` is the level separator, spaces are literal). If plutil mis-parses, fall back to a Python `plistlib` round-trip (load exported plist, set `pl["Window Settings"]["Homebrew"]["Font"] = base64.b64decode(blob)`, write, import).
+2. **`targets.darwin.defaults` option name/shape.** Confirm the home-manager option is `targets.darwin.defaults.<domain>.<key>` at this pin (the `modules/targets/darwin/user-defaults` module exists). If the path differs, set the `Default Bookmark Guid` via a small `home.activation` `defaults write` instead.
+3. **Dynamic profile "Use Non-ASCII Font" key name.** Confirm iTerm reads `"Use Non-ASCII Font"` (boolean) and `"Non Ascii Font"` (string) from dynamic-profile JSON the same as from the main plist. If the JSON expects different casing, adjust.
+4. **Terminal blob validity at apply.** After apply (Terminal quit), open Terminal → the Homebrew profile shows MesloLGS Nerd Font 14. If the blob doesn't take, regenerate via the documented Swift snippet on the actual machine (handles any local font-name nuance).
+
+## Testing
+
+Per project convention (no automated tests), manual verification in the plan:
+
+1. **Pre-flight:** capture `defaults read com.googlecode.iterm2 "New Bookmarks"` font values (Monaco 20) and `defaults read com.apple.Terminal "Window Settings.Homebrew.Font"` (current blob); confirm DynamicProfiles dir empty.
+2. **Eval gates (pre-apply):** the module evals; `home.file."Library/Application Support/iTerm2/DynamicProfiles/nix.json"` is present; `targets.darwin.defaults` resolves; `nix/darwin/defaults.nix` no longer references `com.googlecode.iterm2`; agent@linux build is a no-op (isDarwin guard).
+3. **After `./apply`:**
+   - `~/Library/Application Support/iTerm2/DynamicProfiles/nix.json` exists (symlink), contains the two profiles with `MesloLGSNF-Regular 14`.
+   - `defaults read com.googlecode.iterm2 "Default Bookmark Guid"` → `95362E86-…`.
+   - `defaults read com.apple.Terminal "Window Settings.Homebrew.Font"` → a blob decoding to MesloLGSNF-Regular 14 (compare to the source blob, or `plutil -p`).
+   - **Manual visual:** relaunch iTerm → Default window uses MesloLGS Nerd Font; starship branch glyph renders (no missing-glyph box). Select `tmux (nix)` → tmux windows use it. Quit+reopen Terminal.app → Homebrew profile uses it.
+4. **Idempotence:** second `./apply` — dynamic-profile file unchanged; the Terminal activation re-injects the same blob (no-op effect).
+
+## Risk and rollback
+
+**Risk profile:** Low-medium. iTerm side is low-risk (dynamic profiles are additive, non-destructive, separate file). Terminal side is the riskier part: the `defaults import` replaces the com.apple.Terminal domain from the exported+modified copy (preserves everything else; tiny race only if Terminal writes between export and import — mitigated by quit-first guidance). The stored blob is opaque but documented/regenerable.
+
+**Rollback:** `git revert` the slice + `./apply`. The iTerm dynamic-profile file is removed (iTerm reverts to the original Default/tmux profiles automatically); `Default Bookmark Guid` reverts. For Terminal, the activation stops running; the last-imported font persists until manually changed (re-set the Homebrew profile font by hand if reverting fully). No data loss — iTerm's own profiles were never edited.
+
+## Out of scope
+
+- **Other iTerm/Terminal settings** (colors, keybindings, window size) — fonts only.
+- **The "tmux" iTerm integration auto-pointing at the new profile** — tmux isn't GUID-pinned, so the user selects `tmux (nix)` manually; not worth special machinery.
+- **Generating the NSFont blob at activation time** — rejected (Xcode-CLT dependency + per-apply swift cost); stored blob with regen comment instead.
+- **Other terminal emulators** (Alacritty, kitty, etc.) — not installed/used.
+
+## Cross-references
+
+- Master design: `docs/superpowers/specs/2026-05-22-nix-migration-design.md`
+- nix-firstrun slice (the original font attempt): `docs/superpowers/specs/2026-05-26-nix-firstrun-design.md`
+- Status doc (local, uncommitted): `docs/superpowers/nix-migration-status.md` — closes the reopened iTerm/Terminal font deferral
+- Migration guide: `nix/README.md`

--- a/nix/README.md
+++ b/nix/README.md
@@ -635,6 +635,29 @@ custom_environments is migrated.
 If your private flake adds `home.file` entries or `programs.git.ignores`, Nix
 module merging handles additive entries; conflicting keys need `lib.mkForce`.
 
+For the nix-terminal-fonts slice (iTerm2 + Terminal.app Nerd Font, declarative):
+
+Closes the terminal-font deferral. The nix-firstrun attempt wrote a top-level
+`Normal Font` pref (ignored — the font lives per-profile) with a typo'd
+PostScript name. This slice patches the font onto your EXISTING profiles in
+place via a Python plistlib `defaults export → modify → import` round-trip
+(`nix/profiles/default/patch-terminal-fonts.py`, run from a home-manager
+activation):
+
+- **iTerm2** — the `Default` and `tmux` profiles get `Normal Font` /
+  `Non Ascii Font` set to `MesloLGSNF-Regular 14` ("MesloLGS Nerd Font").
+- **Terminal.app** — the `Homebrew` profile's `Font` (a binary NSFont blob,
+  generated once via Swift and stored with a regen comment) is set.
+
+**CONSTRAINT: quit iTerm2 and Terminal.app before `./apply`.** Both rewrite
+their prefs on quit, so a running app reverts the change. Relaunch them after
+applying to see the font. The patch is idempotent.
+
+**Changing the font:** edit `font` in `nix/profiles/default/terminal-fonts.nix`.
+For Terminal.app, also regenerate the NSFont blob (the Swift one-liner is in the
+file's comment). The font itself is installed by the `font-meslo-lg-nerd-font`
+cask (nix-darwin slice), not here.
+
 The same shape applies to future slices that migrate a plugin or rsync
 source: add the new options to your private flake, delete the now-orphaned
 rsync source from your private repo, and trust the activation cleanup.

--- a/nix/darwin/defaults.nix
+++ b/nix/darwin/defaults.nix
@@ -303,20 +303,6 @@
       "com.apple.dt.Xcode" = {
         DVTTextTabKeyIndentBehavior = "Always";
       };
-
-      # ----- iTerm 2 -----
-      # iTerm stores `Normal Font` as binary-encoded NSFont data, not a
-      # plain string. Writing the string form here is a placeholder — iTerm
-      # ignores it on launch. The Nerd Font itself is installed by the
-      # nix-darwin slice's cask; the actual font selection is a manual
-      # one-time step (iTerm → Settings → Profiles → Text → Font). To make
-      # this declarative for real, a future slice can capture the binary
-      # bytes from a working machine and write them via `defaults write -data`.
-      "com.googlecode.iterm2" = {
-        "Normal Font"        = "MesloLGS-NF-Regular 14";
-        "Non Ascii Font"     = "MesloLGS-NF-Regular 14";
-        "Use Non-ASCII Font" = false;
-      };
     };
   };
 

--- a/nix/profiles/default/default.nix
+++ b/nix/profiles/default/default.nix
@@ -5,6 +5,7 @@
   imports = [
     ./claude.nix
     ./cli-tools.nix
+    ./terminal-fonts.nix
   ];
 
   # `settings.user.{name,email,signingkey}` is the current home-manager

--- a/nix/profiles/default/patch-terminal-fonts.py
+++ b/nix/profiles/default/patch-terminal-fonts.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Patch terminal fonts in place via a cfprefsd-safe defaults export/import.
+
+Usage: patch-terminal-fonts.py <font> <terminal-nsfont-blob-base64>
+
+- iTerm2 (com.googlecode.iterm2): set Normal Font / Non Ascii Font on every
+  "New Bookmarks" profile named "Default" or "tmux" (matched by name, so it's
+  order- and count-independent and leaves other profiles alone).
+- Terminal.app (com.apple.Terminal): set the "Homebrew" profile's Font to the
+  NSKeyedArchiver NSFont blob (bytes -> <data>), creating the key if absent.
+
+Each domain is round-tripped through `defaults export`/`defaults import` so the
+write goes through cfprefsd cleanly. The owning app must NOT be running during
+apply, or it will rewrite its prefs on quit and revert these changes.
+"""
+import base64
+import os
+import plistlib
+import subprocess
+import sys
+import tempfile
+
+DEFAULTS = "/usr/bin/defaults"
+
+
+def patch_domain(domain, mutate):
+    fd, tmp = tempfile.mkstemp(suffix=".plist")
+    os.close(fd)
+    try:
+        if subprocess.run([DEFAULTS, "export", domain, tmp]).returncode != 0:
+            return
+        with open(tmp, "rb") as f:
+            pl = plistlib.load(f)
+        if not mutate(pl):
+            return
+        with open(tmp, "wb") as f:
+            plistlib.dump(pl, f)
+        # Propagate a failed import instead of silently succeeding — otherwise
+        # ./apply reports success while the font was never actually written.
+        subprocess.run([DEFAULTS, "import", domain, tmp], check=True)
+    finally:
+        os.unlink(tmp)
+
+
+def main():
+    font = sys.argv[1]
+    term_blob = base64.b64decode(sys.argv[2])
+
+    def iterm(pl):
+        bookmarks = pl.get("New Bookmarks")
+        if not isinstance(bookmarks, list):
+            return False
+        changed = False
+        for profile in bookmarks:
+            if isinstance(profile, dict) and profile.get("Name") in ("Default", "tmux"):
+                profile["Normal Font"] = font
+                profile["Non Ascii Font"] = font
+                changed = True
+        return changed
+
+    def terminal(pl):
+        settings = pl.get("Window Settings")
+        if not isinstance(settings, dict) or not isinstance(settings.get("Homebrew"), dict):
+            return False
+        settings["Homebrew"]["Font"] = term_blob
+        return True
+
+    patch_domain("com.googlecode.iterm2", iterm)
+    patch_domain("com.apple.Terminal", terminal)
+
+
+if __name__ == "__main__":
+    main()

--- a/nix/profiles/default/terminal-fonts.nix
+++ b/nix/profiles/default/terminal-fonts.nix
@@ -1,0 +1,31 @@
+{ pkgs, lib, ... }:
+let
+  font = "MesloLGSNF-Regular 14";   # "MesloLGS Nerd Font" 14pt; PostScript name + size
+
+  # NSKeyedArchiver-encoded NSFont for "MesloLGSNF-Regular" at 14pt, base64.
+  # Terminal.app stores profile fonts as this binary blob. Regenerate with:
+  #   swift -e 'import AppKit; let f = NSFont(name: "MesloLGSNF-Regular", size: 14)!; print(try! NSKeyedArchiver.archivedData(withRootObject: f, requiringSecureCoding: false).base64EncodedString())'
+  terminalFontBlob =
+    "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGkCwwVFlUkbnVsbNQNDg8QERITFFZOU1NpemVYTlNmRmxhZ3NWTlNOYW1lViRjbGFzcyNALAAAAAAAABAQgAKAA18QEk1lc2xvTEdTTkYtUmVndWxhctIXGBkaWiRjbGFzc25hbWVYJGNsYXNzZXNWTlNGb250ohkbWE5TT2JqZWN0CBEaJCkyN0lMUVNYXmdud36FjpCSlKmuucLJzAAAAAAAAAEBAAAAAAAAABwAAAAAAAAAAAAAAAAAAADV";
+in
+lib.mkIf pkgs.stdenv.isDarwin {
+  # Patch the font onto the EXISTING iTerm "Default"/"tmux" profiles and
+  # Terminal.app's "Homebrew" profile in place (rather than creating parallel
+  # dynamic profiles, which don't auto-take-over the default/tmux roles). A
+  # Python plistlib `defaults export -> modify -> defaults import` round-trip
+  # writes through cfprefsd cleanly and matches profiles by name (order- and
+  # count-independent).
+  #
+  # CONSTRAINT: iTerm and Terminal.app must be QUIT during ./apply — both
+  # rewrite their prefs on quit and would otherwise revert these changes.
+  # Idempotent: re-running sets the same values.
+  home.activation.terminalFonts =
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      # No `|| true`: the patcher already skips absent preference domains
+      # gracefully (a failed `defaults export` is treated as "not present"), so
+      # any error that escapes here is real and should fail the activation
+      # rather than leave ./apply reporting a success that didn't happen.
+      ${pkgs.python3}/bin/python3 ${./patch-terminal-fonts.py} \
+        ${lib.escapeShellArg font} ${lib.escapeShellArg terminalFontBlob}
+    '';
+}


### PR DESCRIPTION
## Summary

Closes the terminal-font deferral (reopened after nix-firstrun's plain-string attempt was found not to work — the font lives per-profile, and the PostScript name was typo'd).

- **iTerm2** — patches the existing `Default` and `tmux` profiles' `Normal Font` / `Non Ascii Font` to `MesloLGSNF-Regular 14` ("MesloLGS Nerd Font").
- **Terminal.app** — sets the `Homebrew` profile's `Font` to a precomputed NSKeyedArchiver NSFont blob (generated once via Swift, stored with a regen comment).
- Both via a Python `plistlib` `defaults export → modify → import` round-trip (`nix/profiles/default/patch-terminal-fonts.py`) run from a darwin-gated home-manager activation. Profiles matched by name; cfprefsd-safe; idempotent.
- Removes the stale, ignored `CustomUserPreferences."com.googlecode.iterm2"` font keys from `nix/darwin/defaults.nix`.

## Approach note

Originally designed around iTerm Dynamic Profiles; pivoted during implementation because dynamic profiles create *parallel* profiles that don't auto-take-over the default/tmux roles (the `Default Bookmark Guid` pref is clobbered by a running iTerm; tmux isn't GUID-pinned). In-place patching of the existing profiles is what satisfies the goal. The git history (spec → plan → revise → feat) reflects the pivot; the spec's Decision 1 documents the rationale.

## Constraint

**Quit iTerm2 and Terminal.app before `./apply`** — both rewrite their prefs on quit and would otherwise revert the change. Relaunch to see the font. The font itself is installed by the `font-meslo-lg-nerd-font` cask (nix-darwin slice), not here.

## Test plan

- [x] iTerm `Default` + `tmux` profiles → `MesloLGSNF-Regular 14` (Normal + Non Ascii); exactly 2 profiles, no leftover `(nix)` dupes.
- [x] Terminal `Window Settings.Homebrew.Font` present, decodes to contain `MesloLGSNF-Regular`.
- [x] Stale `com.googlecode.iterm2` block gone from `nix/darwin/defaults.nix`; other domains intact.
- [x] `default@x86_64-linux` build is a no-op (isDarwin guard).
- [x] Visual: glyphs render in iTerm + Terminal (user-confirmed).
- [x] Idempotent re-apply.

## Stacks on

#75 (nix-homedir)