### PR TITLE
fix(nix): complete custom git-* subcommands in zsh

### DIFF
--- a/nix/profiles/all/shells.nix
+++ b/nix/profiles/all/shells.nix
@@ -226,6 +226,13 @@ in {
     completionInit = ''
       zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
       autoload -Uz compinit && compinit
+
+      # zsh's bundled `_git` completion does NOT auto-discover custom
+      # `git-<cmd>` executables on $PATH (e.g. ~/bin/git-superprune) — unlike
+      # git's own bash completion. Register them as git subcommands via the
+      # documented user-commands style so `git <cmd><TAB>` completes them.
+      # The expansion takes every `git-*` on $PATH and strips the `git-` prefix.
+      zstyle ':completion:*:*:git:*' user-commands ''${''${(M)''${(k)commands}:#git-*}/git-/}
     '';
 
     # .zprofile content (PATH setup). Brew binaries are now on PATH system-wide


### PR DESCRIPTION
## Problem
After the Nix migration, `git superprune`/`git cpr`/etc. (the `~/bin/git-*` scripts migrated in the homedir slice) stopped tab-completing as `git <cmd>` in zsh.

## Root cause
The scripts are present, executable, on `$PATH`, and git itself discovers them (`git --list-cmds=others` lists them). The gap is purely zsh completion: now that Nix provides zsh + git, the active completion is **zsh's bundled `_git`**, which — unlike git's own bash completion — does **not** auto-discover custom `git-*` executables on `$PATH`. Its file header documents that you must register them via the `user-commands` zstyle.

## Fix
Add the documented one-liner to `programs.zsh.completionInit` (derives the list from every `git-*` on `$PATH`, stripping the prefix):

```zsh
zstyle ':completion:*:*:git:*' user-commands ${${(M)${(k)commands}:#git-*}/git-/}
```

Bash is unaffected (git's bash completion already lists these via `git --list-cmds=others`).

## Verification
- The expansion yields exactly the 8 custom commands (plus other `git-*` on PATH).
- Nix `''`-string escaping renders to valid, parse-clean zsh.
- Definitive check (after `./apply` + a fresh shell): `git super<TAB>` → `superprune`.