### PR TITLE
feat(nix): Touch ID for sudo + ban tombstone comments

### DIFF
--- a/apply
+++ b/apply
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 # Flat, Bash-3.2-safe entrypoint. Runs start-to-finish in the invoking shell
-# (no self re-exec) so it works under stock macOS /bin/bash 3.2.57 — the plugin
-# framework that needed Bash 5 was collapsed in the framework-collapse slice.
-# Nix still provides a general-purpose Bash 5 via home.packages.
+# (no self re-exec) so it works under stock macOS /bin/bash 3.2.57. Nix
+# provides a general-purpose Bash 5 via home.packages for everything else.
 
 set -euo pipefail
 

--- a/apply
+++ b/apply
@@ -33,12 +33,6 @@ environment_get_current
 config_load
 
 if [ "$(uname -s)" = Darwin ]; then
-  echo 'Many of the following commands will need root access'
-  echo 'Please enter your password to (hopefully) only be prompted once'
-  sudo -v
-  # Keep-alive: refresh the sudo timestamp until this script exits.
-  while true; do sudo -n true; sleep 30; kill -0 "$$" || exit; done 2>/dev/null &
-
   # nix-darwin's homebrew module runs `brew bundle` on activate but does NOT
   # install brew itself — ensure it is present first.
   source ./framework/compat

--- a/framework/compat
+++ b/framework/compat
@@ -4,10 +4,6 @@
 # mas apps / a few escape-hatched brews via `brew bundle`, but it does not
 # install brew itself, so ./apply sources this and calls compat_ensure_homebrew
 # on macOS before activating nix-darwin.
-#
-# (This file used to also bootstrap a modern Bash via `brew install bash`. That
-# is gone — the framework-collapse slice made ./apply run on stock Bash 3.2.57,
-# and Nix now provides the general-purpose Bash 5.)
 
 compat_ensure_homebrew () {
   if ! command -v brew >/dev/null 2>&1; then

--- a/lib/nix
+++ b/lib/nix
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-# Nix install + activation logic, sourced directly by ./apply. (Formerly the
-# `nix` plugin; the plugin framework was collapsed in the framework-collapse
-# slice.) Depends only on framework/logging (log/debug/error) and the
+# Nix install + activation logic, sourced directly by ./apply. Depends only on
+# framework/logging (log/debug/error) and the
 # DOTFILES_{ROOT_DIR,ENVIRONMENT,NIX_SKIP} globals.
 
 # Nix install/profile locations differ by OS: macOS uses the multi-user daemon

--- a/nix/darwin/base.nix
+++ b/nix/darwin/base.nix
@@ -22,13 +22,11 @@
   # System-wide PATH for brew binaries. Casks ship CLI tools under
   # /opt/homebrew/bin/ (e.g., 1password-cli, aws-vault). The user's
   # ~/.nix-profile/bin/ stays ahead in PATH for interactive shells; this
-  # is the system baseline. Replaces the brewPathSetup let-binding from
-  # the previous shells.nix.
+  # is the system baseline.
   environment.systemPath = [ "/opt/homebrew/bin" "/opt/homebrew/sbin" ];
 
-  # Declarative login-shell management (replaces the chshAndEtcShells
-  # home-manager activation). nix-darwin writes /etc/passwd via dscl and
-  # ensures the shell is in /etc/shells. No marker file; no interactive
+  # Declarative login-shell management. nix-darwin writes /etc/passwd via dscl
+  # and ensures the shell is in /etc/shells. No marker file; no interactive
   # prompt; idempotent.
   environment.shells = [
     "/Users/${username}/.nix-profile/bin/zsh"
@@ -53,11 +51,10 @@
     reattach    = true;
   };
 
-  # Xcode license acceptance (replaces plugins/xcode/xcode's license logic).
-  # Runs as root during activation; xcodebuild short-circuits if the license
-  # is already accepted, so it's idempotent. The `|| true` ensures activation
-  # continues if Xcode isn't installed yet (e.g., first apply before
-  # masApps.Xcode finishes downloading).
+  # Xcode license acceptance. Runs as root during activation; xcodebuild
+  # short-circuits if the license is already accepted, so it's idempotent. The
+  # `|| true` ensures activation continues if Xcode isn't installed yet (e.g.,
+  # first apply before masApps.Xcode finishes downloading).
   system.activationScripts.xcodeLicense.text = ''
     if [ -x /usr/bin/xcodebuild ]; then
       /usr/bin/xcodebuild -license accept 2>/dev/null || true
@@ -100,18 +97,15 @@
       "visual-studio-code"
       "vlc"
       "xquartz"
-      # New: Nerd Font for starship's git-branch glyph (per memory
-      # starship-glyph-fix-deferred). After install, set this as iTerm's
-      # font in Settings → Profiles → Text → Font.
+      # Nerd Font for starship's git-branch glyph. After install, set this as
+      # iTerm's font in Settings → Profiles → Text → Font.
       "font-meslo-lg-nerd-font"
     ];
 
     masApps = {
-      # From environments/all/Brewfile
       Magnet = 441258766;
       Slack  = 803453959;
-      # From plugins/xcode/Brewfile
-      Xcode = 497799835;
+      Xcode  = 497799835;
     };
 
     brews = [
@@ -123,14 +117,10 @@
       # masApp would fail because the `mas` binary is gone. Declare it
       # explicitly here so cleanup respects it.
       "mas"
-      # Escape-hatched (slice 9): nix's pkgs.watchman fails to compile
-      # because the folly C++ dep doesn't build on aarch64-darwin in
-      # the current nixpkgs.
+      # watchman: a brew rather than a nix package because pkgs.watchman fails
+      # to compile — its folly C++ dep doesn't build on aarch64-darwin in the
+      # current nixpkgs.
       "watchman"
-      # (The `bash` + `bash-completion@2` bootstrap helpers were dropped in
-      # the framework-collapse slice — ./apply now runs on stock Bash 3.2.57
-      # and Nix provides the general-purpose Bash 5 via home.packages.
-      # cleanup = "uninstall" removes the old brew bash on the next activation.)
     ];
   };
 }

--- a/nix/darwin/base.nix
+++ b/nix/darwin/base.nix
@@ -38,6 +38,21 @@
     shell = "/Users/${username}/.nix-profile/bin/zsh";
   };
 
+  # Touch ID for sudo. nix-darwin's sudo_local module writes
+  # /etc/pam.d/sudo_local (the Apple-sanctioned drop-in that survives OS
+  # upgrades, unlike editing /etc/pam.d/sudo directly), inserting
+  # pam_tid.so so any `sudo` in a terminal pops the native Touch ID
+  # dialog and falls back to a password if the fingerprint fails.
+  #
+  # `reattach` adds pam_reattach.so so the Touch ID prompt also works
+  # inside tmux/screen sessions — without it, sudo inside `screen`
+  # (see home-files/screenrc) silently falls back to password entry
+  # because the GUI prompt can't attach to the detached session.
+  security.pam.services.sudo_local = {
+    touchIdAuth = true;
+    reattach    = true;
+  };
+
   # Xcode license acceptance (replaces plugins/xcode/xcode's license logic).
   # Runs as root during activation; xcodebuild short-circuits if the license
   # is already accepted, so it's idempotent. The `|| true` ensures activation

--- a/nix/darwin/base.nix
+++ b/nix/darwin/base.nix
@@ -44,8 +44,9 @@
   #
   # `reattach` adds pam_reattach.so so the Touch ID prompt also works
   # inside tmux/screen sessions — without it, sudo inside `screen`
-  # (see home-files/screenrc) silently falls back to password entry
-  # because the GUI prompt can't attach to the detached session.
+  # (see nix/profiles/all/home-files/screenrc) silently falls back to
+  # password entry because the GUI prompt can't attach to the detached
+  # session.
   security.pam.services.sudo_local = {
     touchIdAuth = true;
     reattach    = true;

--- a/nix/darwin/default/homebrew.nix
+++ b/nix/darwin/default/homebrew.nix
@@ -21,7 +21,8 @@
     };
 
     brews = [
-      # Escape-hatched (slice 9): pkgs.argo absent from nixpkgs 26.05.
+      # argo: a brew rather than a nix package because pkgs.argo is absent
+      # from nixpkgs 26.05.
       "argo"
     ];
   };

--- a/nix/profiles/default/claude/rules/no-tombstone-comments.md
+++ b/nix/profiles/default/claude/rules/no-tombstone-comments.md
@@ -5,14 +5,21 @@ narrate the history of how the code reached its current state. Comments must
 explain the code as it exists now — what it does and why — to a reader who
 never saw the prior version. Git history already records what changed.
 
-Avoid comments like:
+A tombstone is a comment whose subject is *this repository's own* removed or
+superseded code. Avoid comments like:
 
 - "There used to be X here, but we removed it because…"
 - "Formerly the Y plugin; the framework was collapsed in slice N…"
-- "Renamed from Z" / "This used to do W"
+- "This used to do W" / "Renamed from our old Z"
 - "No longer needed because…" describing absent code
 
 If the *current* design needs justifying (a non-obvious choice, a workaround,
 a constraint), explain the present rationale directly without referencing what
-was there before. If the only thing a comment conveys is that something
+the code used to be. If the only thing a comment conveys is that our code
 changed, delete it — that belongs in the commit message.
+
+This does **not** ban comments that document an *external* fact to justify a
+surprising current value. Those are present-day rationale, not history of our
+code, and should stay. For example, `# renamed from aws-vault in homebrew-cask`
+explains why a package token looks the way it does today and stops someone
+"correcting" it and breaking the build.

--- a/nix/profiles/default/claude/rules/no-tombstone-comments.md
+++ b/nix/profiles/default/claude/rules/no-tombstone-comments.md
@@ -1,0 +1,18 @@
+# No Tombstone Comments
+
+Do not write comments that describe code which is no longer present, or
+narrate the history of how the code reached its current state. Comments must
+explain the code as it exists now — what it does and why — to a reader who
+never saw the prior version. Git history already records what changed.
+
+Avoid comments like:
+
+- "There used to be X here, but we removed it because…"
+- "Formerly the Y plugin; the framework was collapsed in slice N…"
+- "Renamed from Z" / "This used to do W"
+- "No longer needed because…" describing absent code
+
+If the *current* design needs justifying (a non-obvious choice, a workaround,
+a constraint), explain the present rationale directly without referencing what
+was there before. If the only thing a comment conveys is that something
+changed, delete it — that belongs in the commit message.

--- a/nix/profiles/default/claude/rules/no-tombstone-comments.md
+++ b/nix/profiles/default/claude/rules/no-tombstone-comments.md
@@ -5,8 +5,8 @@ narrate the history of how the code reached its current state. Comments must
 explain the code as it exists now — what it does and why — to a reader who
 never saw the prior version. Git history already records what changed.
 
-A tombstone is a comment whose subject is *this repository's own* removed or
-superseded code. Avoid comments like:
+A tombstone is a comment whose subject is code that was removed from or
+superseded within the codebase you're editing. Avoid comments like:
 
 - "There used to be X here, but we removed it because…"
 - "Formerly the Y plugin; the framework was collapsed in slice N…"
@@ -15,11 +15,11 @@ superseded code. Avoid comments like:
 
 If the *current* design needs justifying (a non-obvious choice, a workaround,
 a constraint), explain the present rationale directly without referencing what
-the code used to be. If the only thing a comment conveys is that our code
+the code used to be. If the only thing a comment conveys is that the code
 changed, delete it — that belongs in the commit message.
 
-This does **not** ban comments that document an *external* fact to justify a
-surprising current value. Those are present-day rationale, not history of our
-code, and should stay. For example, `# renamed from aws-vault in homebrew-cask`
-explains why a package token looks the way it does today and stops someone
-"correcting" it and breaking the build.
+This does **not** ban comments that document a fact external to the codebase
+to justify a surprising current value. Those are present-day rationale, not
+the history of the code, and should stay. For example,
+`# renamed from aws-vault in homebrew-cask` explains why a package token looks
+the way it does today and stops someone "correcting" it and breaking the build.


### PR DESCRIPTION
## Summary

Two changes:

1. **Touch ID for sudo** (`feat(nix)`) — adds `security.pam.services.sudo_local` with `touchIdAuth` + `reattach` in `nix/darwin/base.nix`. Every interactive `sudo` now pops the native Touch ID dialog (password fallback), and `reattach` makes it work inside `screen`/`tmux` too. Also removes the up-front `sudo -v` priming + keep-alive loop from `apply`: nix-darwin refuses to activate unless already root and doesn't self-elevate, so the `sudo` in `lib/nix` stays, but the priming did no privileged work — downstream steps each invoke `sudo` themselves.

2. **No tombstone comments** (`docs`) — adds a Claude rule at `nix/profiles/default/claude/rules/no-tombstone-comments.md` forbidding comments that narrate removed code / migration history instead of explaining the code as it stands, then sweeps existing tombstones from `apply`, `lib/nix`, `framework/compat`, `base.nix`, and `homebrew.nix`. Present-tense rationale (why `watchman`/`argo` are brews, the Nerd Font setup step) is kept and rephrased; the `# renamed from … in homebrew-cask` cask notes are intentionally kept since they justify non-obvious current names.

## Notes / follow-ups

- **Touch ID is not active until activation runs.** It needs a one-time `sudo darwin-rebuild switch` (the bootstrap is password-then-fingerprint, since `/etc/pam.d/sudo_local` doesn't exist until this activates). Run from this branch or after merge.
- The new rule isn't linked into `~/.claude/rules/` until `./apply` runs home-manager.

## Test plan

- `bash -n` parse-check passes on `apply`, `lib/nix`, `framework/compat` (Bash 3.2 parser).
- `nix-instantiate --parse` passes on `base.nix` and `homebrew.nix`.
- `darwin-rebuild build` succeeds and generates the expected `/etc/pam.d/sudo_local`:
  ```
  auth       optional       …/pam_reattach.so
  auth       sufficient     pam_tid.so
  ```
- After activation: open a new terminal, run `sudo -v`, confirm the Touch ID dialog appears (and works inside `screen`).