### PR TITLE
docs: comprehensive CLAUDE.md + README set for the Nix-era repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,11 @@ configurations.
 - `apply` - Flat entry script (Bash-3.2-safe; no plugin framework)
 - `lib/nix` - Nix install + home-manager / nix-darwin activation logic (sourced by `apply`)
 - `framework/` - Small sourced helpers: `logging`, `config` (`~/.dotfilesrc`), `environment` (resolve/persist the active environment), `compat` (ensure Homebrew on macOS)
-- `nix/` - The declarative configuration (flake, home-manager profiles, nix-darwin system layer)
-- `environments/` - Repo-managed environments (`all/` shared, `default/` machine-specific)
-- `custom_environments/` - Git-ignored user customizations (private flake + `home/` overlay)
+- `nix/` - The declarative configuration (flake, home-manager profiles, nix-darwin system layer). See `nix/CLAUDE.md`.
+- `custom_environments/` - Git-ignored; a separate private repo (its own flake consuming the public one) supplying per-machine config
+
+Subtree guides: `framework/CLAUDE.md` (bootstrap internals), `nix/CLAUDE.md`
+(where config goes + the layering model).
 
 ## Running
 
@@ -26,7 +28,12 @@ DOTFILES_DEBUG=1 ./apply  # Verbose logging
 - `apply` and `framework/*` must run on stock macOS Bash 3.2.57 (no Bash-4-only
   features: no `local -n` namerefs, no `${var^^}` case modification, etc.). Nix
   provides a general-purpose Bash 5 for everything else.
-- Config persisted to `~/.dotfilesrc` (`DOTFILES_ENVIRONMENT`, …).
+- Config persisted to `~/.dotfilesrc`. `DOTFILES_ENVIRONMENT` is written only
+  when the env prompt runs (some env besides bare `default` exists); the
+  selection — which may be `default` — is stored. With only `default`/none,
+  it's used implicitly and nothing is persisted.
+- The macOS system layer (nix-darwin) is always built from the public `default`
+  profile; private envs only affect home-manager.
 - New configuration belongs in `nix/` (home-manager / nix-darwin), not in new
   shell plugins — the plugin framework was retired.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ git clone https://github.com/ianwremmel/dotfiles
 
 ## Usage
 
-Apply the repo to your system. You'll be prompted on first run.
+Apply the repo to your system (you may be prompted to pick an environment on
+first run — see Environments).
 
 ```bash
 cd dotfiles
@@ -41,51 +42,54 @@ that setting from the file to be reprompted on next run.
 
 ## Environments
 
-Environments define config for a particular computer (or category of computers).
-For example, you might have an environment called "home" and an environment
-called "work".
+An environment names the config for a computer (or category of computers) — e.g.
+"home" or "work". When you have environments under `custom_environments/` to
+choose from, `./apply` prompts on first run and persists the choice as
+`DOTFILES_ENVIRONMENT` in `~/.dotfilesrc`; with none, it uses `default` without
+prompting. The active environment selects what to build: a built-in public
+profile (`default` or `agent`, under `nix/profiles/`), or — for any other name —
+a private flake at `custom_environments/<env>/nix`. A name that is neither a
+built-in profile nor a private flake fails the build.
 
-There are two special environment names with extra behavior. Configuration in
-the `all` environment gets applied to every device regardless of any other
-environment name being set. `default` gets applied on any device that doesn't
-have a specific environment set. It's entirely possible (likely, even) that
-these are the only environments you'll need.
+Configuration lives in two layers:
 
-Environments are are defined in two place:
-
-- `environments` - these are defined in this reposity. These are @ianwremmel's
-  custom dotfiles. You may be happy with them or you may wish to customize them.
-  They tend to change regularly (particularly his brewfile, so you'll likely
-  want to copy `all` and `default` to your `custom_environments`)
-- `custom_environments` - This folder is gitignored. You can choose to put your
-  environments here and not track them, but you'll probably want to create a
-  separate repo that you checkout to this folder. If you create a folder called
-  e.g. `all` in `custom_environments`, it will be used exclusively in place of
-  the `all` in `environments`. If that folder is empty, you'll be working from a
-  completely clean slate (other than the Nix-managed configuration)
+- **Public** (`nix/`) — @ianwremmel's declarative config. The `all` profile is
+  composed into every machine; selectable profiles layer on top (`default` for
+  personal machines, `agent` for lean/headless boxes). The first-run prompt
+  offers only environments found on disk (`custom_environments/*`, plus the
+  legacy `environments/*` if present) — not the built-in nix profiles — so
+  `agent` is not currently offered there. Reach it by setting
+  `DOTFILES_ENVIRONMENT=agent` (or adding a `custom_environments/agent`). Fork
+  them if you want something different. See `nix/`.
+- **Private** (`custom_environments/`) — git-ignored, typically a separate repo
+  you clone here. Each environment is a flake at `custom_environments/<env>/nix`
+  that consumes the public flake and layers your machine-specific config on top.
+  See `nix/README.md` for the template. With no private flake, you build the
+  public profile directly.
 
 ## How it works
 
 `./apply` is a thin bootstrapper. It:
 
-1. Resolves the active environment (prompting once when more than one exists) and
-   persists it to `~/.dotfilesrc`. The environment selects the home-manager
-   profile and any private flake under `custom_environments/<env>/nix`.
+1. Resolves the active environment (see Environments). It selects the
+   home-manager profile and any private flake under
+   `custom_environments/<env>/nix`.
 2. On macOS, ensures Homebrew is present (nix-darwin's homebrew module needs it).
 3. Installs Nix (if needed), generates `nix/host.nix`, then builds and activates
    the home-manager configuration and — on macOS — the nix-darwin system layer.
-   This is where the configuration lives (see `nix/`).
+   This is where the configuration lives (see `nix/`). The nix-darwin layer is
+   always built from the public `default` profile; private envs only affect
+   home-manager.
 
 The bootstrap logic lives in `apply` plus a few small sourced helpers under
-`framework/` (`logging`, `config`, `environment`, `compat`) and `lib/nix`. The
-homegrown plugin framework that predated the Nix migration has been retired; new
+`framework/` (`logging`, `config`, `environment`, `compat`) and `lib/nix`. New
 configuration belongs in `nix/`.
 
 ## Conventions
 
 - Scripts are extensionless and rely on their shebang for interpreter.
 - Environment variables and globals are all caps, with underscores as
-  separaters.
+  separators.
 - Functions and local variables are snake case.
 - `apply` and the `framework/*` helpers are sourced/run as a single process and
   must work on stock macOS Bash 3.2.57 — no Bash-4-only features (`local -n`

--- a/framework/CLAUDE.md
+++ b/framework/CLAUDE.md
@@ -1,0 +1,78 @@
+# Bootstrap layer (`apply`, `framework/`, `lib/nix`)
+
+`./apply` (repo root) is a flat bootstrapper that resolves the active
+environment, ensures prerequisites, and hands off to Nix. It sources these
+helpers in order; they share one process and mutate its globals, so they are
+sourced, not executed.
+
+## Hard constraint: Bash 3.2
+
+`apply` and every `framework/*` helper must run on stock macOS
+`/bin/bash` (3.2.57) with no re-exec. **No Bash-4+ features**: no `local -n`
+namerefs, no `${var^^}`/`${var,,}` case modification, no associative arrays,
+no `mapfile`/`readarray`. Nix provides a general-purpose Bash 5 for everything
+else. `shellcheck` lints these (bash only — it can't check zsh). Parse-check
+with `/bin/bash -n <file>`.
+
+## Flow (`apply`)
+
+1. Export `DOTFILES_ROOT_DIR` (the repo dir).
+2. Source `logging`, `config`, `environment`, then `lib/nix`.
+3. Create `~/.dotfilesrc` (mode 0600) if missing.
+4. `environment_get_current` (echoes the active environment; persists the
+   selection only when the prompt runs — see the helper below) → `config_load`
+   (exports every `~/.dotfilesrc` key as an env var).
+5. macOS only: source `compat`; `compat_ensure_homebrew`.
+6. `dotfiles_nix_apply` — the handoff to Nix.
+
+`apply` itself never elevates; the `sudo` calls live downstream
+(`compat_ensure_homebrew`'s `installer`, the Nix installer, and `lib/nix`'s
+`sudo -H` nix-darwin activation), each prompting as needed.
+
+## Helpers
+
+- **`logging`** — `log` (stdout), `error` (stderr), `debug` (stderr, only when
+  `DOTFILES_DEBUG` is non-empty).
+- **`config`** — read/write `~/.dotfilesrc` (`config_read`, `config_write`,
+  `config_load`); path overridable via `DOTFILES_CONFIG_FILE`. `config_load`
+  exports every non-comment `KEY=value` line.
+- **`environment`** — `environment_get_current` returns the persisted
+  `DOTFILES_ENVIRONMENT` if set; otherwise lists candidate environments
+  (`custom_environments/*`, plus the legacy `environments/` dir if present,
+  excluding `all`). If the only candidate is `default` (or there are none) it
+  uses `default` without prompting or persisting; if any other env exists
+  (even one) it prompts and persists the choice.
+- **`compat`** (macOS) — ensure Homebrew exists (nix-darwin's homebrew module
+  drives `brew` but won't install it) and disable its analytics.
+
+## `lib/nix`
+
+`dotfiles_nix_apply`:
+
+1. Bail early if `DOTFILES_NIX_SKIP=1`.
+2. Install Nix if absent — Determinate installer on macOS (daemon; SIP
+   requires it), official single-user installer on Linux — then source its
+   profile script onto PATH.
+3. Write **`nix/host.nix`** (untracked): `{ username; profile; }`. The flake
+   refuses to build without it.
+4. `nix eval … builtins.currentSystem` → `$system`.
+5. Pick the flake: if `custom_environments/<profile>/nix/flake.nix` exists,
+   build that private flake with `--override-input public path:.../nix` and
+   target `homeConfigurations."<system>"`; otherwise build the public flake's
+   `homeConfigurations."<profile>@<system>"`. Build to a temp out-link, run
+   its `activate`.
+6. macOS only: activate nix-darwin —
+   `darwinConfigurations."default@<system>"` (only `default` has a darwin
+   module). First run bootstraps via `sudo -H nix run nix-darwin -- switch`;
+   later runs use `sudo -H darwin-rebuild switch`. **`-H` is required** so
+   nix-darwin writes state under root, not the invoking user's `$HOME`. The
+   flake ref is `path:.../nix` (non-git fetcher) so untracked `host.nix` is
+   visible.
+
+## Env vars
+
+`DOTFILES_ENVIRONMENT` (persisted; selects profile), `DOTFILES_DEBUG` (verbose
+logging), `DOTFILES_NIX_SKIP=1` (skip Nix entirely), `DOTFILES_ROOT_DIR` (set
+by `apply`).
+
+New configuration belongs in `nix/`, not here — see `../nix/CLAUDE.md`.

--- a/nix/CLAUDE.md
+++ b/nix/CLAUDE.md
@@ -1,0 +1,83 @@
+# Nix configuration (`nix/`)
+
+This flake *is* the configuration. `./apply` only bootstraps it (see
+`../framework/CLAUDE.md`). User-level state is home-manager; macOS system-level
+state is nix-darwin. New configuration goes here — not in shell scripts.
+
+For the human-facing tour (install, manual build, private-flake template,
+backout) see `README.md` in this directory. This file is the map for *editing*
+the config.
+
+## Layering
+
+`flake.nix` composes modules in order; each layer can extend or override the
+ones below it.
+
+- **`home.nix`** — base infrastructure: username, homeDirectory,
+  stateVersion, `allowUnfree`. Rarely edited.
+- **`profiles/all/`** — composed into *every* config by `lib.mkHome`,
+  regardless of profile or private overlay. Anything every machine should get.
+  Split per-feature: `cli-tools` `git` `gpg` `shells` `vim` `home-files`
+  `dotfilesrc-cleanup`.
+- **`profiles/<profile>/`** — selectable. `default` = personal machine (Claude
+  config, personal CLI tools, terminal fonts, git identity + signing);
+  `agent` = headless, intentionally empty.
+- **`darwin/`** (macOS system layer) — `base.nix` (universal: homebrew base,
+  login shell, system PATH, Xcode license, macOS `defaults` via
+  `defaults.nix`) + `default/homebrew.nix` (personal casks/mas/brews). Only
+  `default` has a darwin module — there is no `agent` system layer. (`agent`
+  still has a home-manager config on every system, including macOS.)
+
+The active profile comes from `DOTFILES_ENVIRONMENT` via the untracked
+`host.nix` (`{ username; profile; }`). Home outputs are
+`homeConfigurations."<profile>@<system>"` (one per profile × system). Only
+`default` has a darwin module, so the sole darwin output is
+`darwinConfigurations."default@<system>"` — and `lib/nix` always activates that
+one regardless of the active profile.
+
+## Where things go
+
+- **A CLI tool** → `home.packages` in `profiles/all/cli-tools.nix` (every
+  machine) or `profiles/default/cli-tools.nix` (personal only).
+- **A program with home-manager support** → `programs.<name>` in the matching
+  `profiles/all/*.nix`.
+- **A dotfile** → drop it under `profiles/all/home-files/home/` — every file
+  there is auto-symlinked to `$HOME` 1:1 (files under `bin/` become
+  executable). No module edit needed.
+- **A macOS preference** → `system.defaults.*` in `darwin/defaults.nix`; if the
+  key has no typed option, use `system.defaults.CustomUserPreferences`.
+- **A macOS app** → `homebrew.{casks,masApps,brews}` in `darwin/base.nix`
+  (universal) or `darwin/default/homebrew.nix` (personal). There is no private
+  darwin path yet, so sensitive apps have no declarative home — add them to a
+  public module or install them imperatively (the cleanup policy removes any
+  undeclared brew package on the next apply).
+- **Claude Code config** → `profiles/default/claude/` — files under
+  `agents/ skills/ commands/ rules/ guides/` auto-map to `~/.claude/`;
+  `settings.json` is generated from the attrset in `claude.nix`.
+
+## Conventions
+
+- **Escape hatch for nix-unfriendly packages** → `homebrew.brews` (e.g.
+  `watchman`, `argo`). Comment why.
+- **`homebrew.onActivation.cleanup = "uninstall"`** removes any brew package
+  not declared in the flake — there is no Brewfile. Declared-only.
+- **One-time migrations** are `home.activation` scripts that retire pre-Nix
+  state so home-manager can take over. They vary: most (git, gpg, shells)
+  move the old file to `*.legacy-backup`, some marker-gated (`.hm-migrated`)
+  and some relying on self-idempotent guards (vim, claude); `home-files`
+  deletes exact tracked rsync residue outright (no backup — git has it). They
+  concern existing pre-Nix machines only; fresh installs skip them. Match the
+  existing style when adding one.
+- **`~/.claude/` is managed file-by-file, never as a directory**, so live
+  Claude Code state survives. Same pattern for any dir with live state.
+- **`nix.enable = false`** in `darwin/base.nix` — Determinate's installer owns
+  the daemon; nix-darwin must not fight it.
+- **Private flakes** (`custom_environments/<env>/nix/`) consume this flake as
+  the `public` input and override scalars with `lib.mkForce`. Note any
+  private-side update in `README.md` when migrating something here.
+
+## Pins
+
+`flake.lock` pins nixpkgs / home-manager / nix-darwin to the `26.05` line;
+`home.stateVersion` is `25.11` and nix-darwin's `system.stateVersion` is `5`.
+Don't bump these casually — `./apply` after a bump rebuilds everything.

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,28 +1,38 @@
-# Nix-managed dotfiles (slice)
+# Nix-managed dotfiles
 
-This directory is a [Nix flake](https://nixos.wiki/wiki/Flakes) that manages a
-growing slice of the dotfiles via [home-manager](https://github.com/nix-community/home-manager),
-activated automatically by the `nix` plugin during `./apply`.
+This directory is a [Nix flake](https://nixos.wiki/wiki/Flakes) that manages the
+dotfiles via [home-manager](https://github.com/nix-community/home-manager)
+(user-level) and [nix-darwin](https://github.com/nix-darwin/nix-darwin)
+(macOS system-level). `./apply` activates it automatically.
 
-## Background
+This is the human-facing tour. For *editing* the config — where things go and
+the layering rules — see `CLAUDE.md` in this directory.
 
-The repo is mid-migration from the homegrown plugin framework toward Nix. See
-`docs/superpowers/specs/2026-05-22-nix-migration-design.md` for the design and
-planned phases. So far this manages: the full git config (aliases, body, identity, includes) via `programs.git` plus a one-time activation that retires the legacy rsync-managed `~/.gitconfig`; commit signing — `programs.gpg` + `services.gpg-agent` with per-OS pinentry (`pinentry-mac` on macOS, `pinentry-tty` on Linux), `programs.git.settings.user.signingkey` + `commit.gpgsign` in the `default` profile, and a one-time activation that retires the old plugin-written `~/.gnupg/*.conf`; and shell config — bash and zsh via `programs.bash` + `programs.zsh` (with the prior `.zshrc.d/` and `.bash_profile.d/` modular content folded into the relevant typed options), `.inputrc` via `home.file`, and one-time activations that retire the rsync-managed shell dotfiles plus the `shells` plugin's chsh / /etc/shells logic; and a prompt — starship via `programs.starship` (replacing the retired `powerlevel` plugin and its rsync'd `.p10k.zsh`); and Node.js — fnm via `pkgs.fnm` + shell init injection (replacing the retired `nvm` and `node` plugins), with a one-time activation that installs the LTS version on first apply; and CLI tools — most brew formulas migrated to `home.packages` (a handful of escape-hatched formulas without nix equivalents stay as `homebrew.brews` in nix-darwin); and a system-level layer via nix-darwin managing brew casks (including a Nerd Font for starship), mas-installed apps (including Xcode), the login-shell declaration, and Xcode license acceptance. See Profiles for the layering and Migrating a private custom environment for the private-side migration steps.
+## What it manages
+
+home-manager owns the user environment: the shared git config (aliases,
+includes) and a GPG agent with per-OS pinentry (`programs.gpg` +
+`services.gpg-agent`); bash + zsh (`programs.bash`/`programs.zsh`, with
+`.inputrc`); the starship prompt; Node.js via fnm; vim (`programs.vim`, plugins
+from nixpkgs); a curated set of CLI tools (`home.packages`); and auto-discovered
+home dotfiles. The `default` profile adds git identity + commit signing and
+Claude Code config.
+
+nix-darwin owns the macOS system layer: Homebrew casks / mas apps / escape-hatch
+brews, the login shell, system PATH, Xcode license, and `defaults` (system
+preferences).
 
 ## Install
 
-`./apply` runs the `nix` plugin, which installs Nix if absent and builds and
-activates `homeConfigurations."<profile>@<system>"` for the current machine
-(or a private-flake config if one is set up — see Profiles). The flake
-supports `aarch64-darwin`, `x86_64-darwin`, `x86_64-linux`, and
-`aarch64-linux`.
+`./apply` installs Nix if absent and builds + activates
+`homeConfigurations."<profile>@<system>"` for the current machine (or a private
+flake — see Profiles). Supported systems: `aarch64-darwin`, `x86_64-darwin`,
+`x86_64-linux`, `aarch64-linux`.
 
-- **macOS:** the full framework runs; Nix is installed via the Determinate
-  Systems installer (daemon-based — macOS SIP requires it).
-- **Linux:** `./apply` runs only the nix step (the macOS-only plugins are
-  skipped). Nix is installed single-user with no daemon via the official
-  installer.
+- **macOS** — Nix is installed via the Determinate Systems installer (daemon —
+  macOS SIP requires it); the nix-darwin system layer also activates.
+- **Linux** — Nix is installed single-user, no daemon, via the official
+  installer; only the home-manager layer applies.
 
 To build/activate by hand after Nix is installed:
 
@@ -33,98 +43,80 @@ To build/activate by hand after Nix is installed:
     nix $flags build "path:$PWD#homeConfigurations.\"${profile}@${sys}\".activationPackage" --out-link "$out"
     "$out/activate"
 
-(On a fresh Linux single-user install flakes are not enabled by default, hence
-the `--extra-experimental-features` flag.)
+(Flakes are not enabled by default on a fresh Linux single-user install, hence
+the `--extra-experimental-features` flag. This assumes `nix/host.nix` already
+exists — `./apply` generates it; the flake throws without it. Building a private
+flake by hand differs — see Private profiles.)
 
-## Usage
-
-Edit `home.nix` to add packages (`home.packages`) or program modules
-(`programs.*`), then re-run `./apply` (or the manual build/activate above).
+To add a package or program, edit the relevant module (see `CLAUDE.md`) and
+re-run `./apply`.
 
 ## Profiles
 
-Per-machine profiles select which extra modules layer on top of the shared
-base. Selection reuses the framework's `DOTFILES_ENVIRONMENT` value — no new
-variable — and is loaded the same way on both platforms (`./apply` runs
-`environment_get_current` + `config_load` from the framework). The
-plugin-generated `nix/host.nix` carries both `username` and `profile`.
+A per-machine profile selects which modules layer on top of the shared base.
+Selection reuses the framework's `DOTFILES_ENVIRONMENT` value — no new variable.
+The untracked `nix/host.nix` (generated by `lib/nix`) carries
+`{ username; profile; }`; the flake throws if it's absent.
 
-### Public profiles and layers
-
-`nix/home.nix` is infrastructure (username, homeDirectory, stateVersion,
+`nix/home.nix` is base infrastructure (username, homeDirectory, stateVersion,
 `programs.home-manager.enable`). `lib.mkHome` always composes it with the
-**always-included `all` layer** (shared content every machine gets), plus
-whichever selectable profile is active:
+**always-included `all` layer** (`nix/profiles/all/` — shared content every
+machine gets regardless of profile or private overlay), then the active
+selectable profile:
 
-- `all` — always included via `mkHome`; shared content for every machine
-  regardless of profile or private overlay (currently the shared
-  git config — aliases, body, includes — via `programs.git`, GPG/agent
-  setup with per-OS pinentry: `pinentry-mac` on macOS, `pinentry-tty` on
-  Linux, bash + zsh via `programs.bash` + `programs.zsh` plus `.inputrc` via `home.file`, AND starship as the prompt, AND fnm for Node.js version management, AND a curated set of CLI tools via `home.packages`, AND a system-level layer via nix-darwin managing brew casks (a Nerd Font included), mas apps (including Xcode), the login shell declaration, and Xcode license acceptance).
-- `default` — selectable profile; matches the framework's default
-  `DOTFILES_ENVIRONMENT=default` and adds personal-machine CLI tools
-  (cloud tooling, scripting languages, kubernetes utilities) via
-  `nix/profiles/default/cli-tools.nix`.
-- `agent` — selectable profile for headless / agent boxes; lean.
+- **`all`** — always included: git, GPG/agent, bash + zsh + `.inputrc`,
+  starship, fnm, vim, CLI tools, and auto-discovered home dotfiles.
+- **`default`** — personal machines; adds Claude Code config, personal CLI
+  tools (cloud, kubernetes, IaC), terminal fonts, and git identity + signing.
+- **`agent`** — headless/agent boxes; lean (no extras beyond `all`).
 
-The public flake exposes them as a module library
-(`homeModules.{base,all,default,agent}` + a `lib.mkHome` helper) and as
-ready-made `homeConfigurations."<profile>@<system>"` outputs (one per
-selectable profile × system). When no private flake matches the active
-profile, the plugin builds the matching public config directly.
+The flake exposes these as a module library (`homeModules.{base,all,default,
+agent}` + `lib.mkHome`) and as ready-made `homeConfigurations."<profile>@
+<system>"` outputs. When no private flake matches the active profile, the
+public config is built directly.
 
 ### Darwin configurations (macOS system layer)
 
-In addition to home-manager (user-level), this flake exposes
-`darwinConfigurations.<profile>@<system>` outputs (system-level, macOS-only)
-via nix-darwin. The active profile selects which module from
-`nix/darwin/<profile>/` is included alongside the universal `nix/darwin/base.nix`.
-
-Currently only `default` has a darwin module (`nix/darwin/default/homebrew.nix`).
-The `agent` profile is Linux-only and has no darwin counterpart.
+The flake also exposes `darwinConfigurations` (macOS-only) via nix-darwin, each
+composing a profile module from `nix/darwin/<profile>/` with the universal
+`nix/darwin/base.nix`. Only `default` has a darwin module (there is no
+`agent` system layer — though `agent` still has a home-manager config on every
+system), so the sole output is `darwinConfigurations."default@<system>"` — and
+`lib/nix` always activates it regardless of the active home-manager profile.
 
 System-level concerns owned by nix-darwin (not home-manager):
 
-- Homebrew casks, mas apps, and escape-hatched brews — `homebrew.{casks,masApps,brews}`
-- Login shell declaration — `users.users.<name>.shell` + `environment.shells`
-- System PATH baseline including `/opt/homebrew/{bin,sbin}` — `environment.systemPath`
-- Xcode license acceptance — `system.activationScripts.xcodeLicense`
+- Homebrew casks, mas apps, escape-hatched brews — `homebrew.{casks,masApps,brews}`
+- Login shell — `users.users.<name>.shell` + `environment.shells`
+- System PATH baseline (`/opt/homebrew/{bin,sbin}`) — `environment.systemPath`
+- macOS preferences — `system.defaults` + `CustomUserPreferences`
+- Xcode license — `system.activationScripts.xcodeLicense`
 
-Note: `nix.enable = false` in the base config — Determinate's nix installer
-manages its own daemon and refuses to coexist with nix-darwin's native nix
-management. nix-darwin still does everything else.
+`nix.enable = false` in the base config: Determinate's installer owns the Nix
+daemon and won't coexist with nix-darwin's native management. nix-darwin does
+everything else. Activations are sudo-required (handled by `lib/nix`): a fresh
+machine auto-bootstraps via `sudo -H nix run nix-darwin -- switch …`, later
+applies use `sudo -H darwin-rebuild switch …`.
 
-nix-darwin activations are sudo-required and managed by the `nix` plugin
-(macOS-only branch). On a fresh machine the plugin auto-bootstraps via
-`sudo -H nix run nix-darwin -- switch …`; on subsequent applies it uses
-`sudo -H darwin-rebuild switch …`.
+## Private profiles
 
-### Private profiles
+Private/sensitive config lives in your separate `custom_environments/` repo as a
+**flake** at `custom_environments/<env>/nix/flake.nix`. It consumes the public
+flake as an input, composes on top of it, and exposes
+`homeConfigurations."<system>"` (no profile prefix — the env is implicit in the
+flake's location).
 
-Private/sensitive profiles live in your separate `custom_environments/` repo
-as **flakes** at `custom_environments/<env>/nix/flake.nix`. The private flake
-consumes the public flake as an input, composes on top of it, and exposes
-`homeConfigurations."<system>"` (one per supported system; no profile prefix
-because the env is implicit in the flake's location).
+Two things to know before authoring one:
 
-**Two things to know before authoring one:**
-
-1. **`path:` flake refs require git-tracked files.** When `lib/nix`
-   builds your private flake, it uses `path:custom_environments/<env>/nix`.
-   Because that path lives inside a git repo (typically your private
-   `custom_environments` repo, cloned manually into `custom_environments/`),
-   Nix's path fetcher applies git-tree semantics — only files tracked in that
-   repo are visible. **Commit your private flake files** to your private repo before
-   the first `./apply`. (For one-off throwaway testing without the private
-   repo, `git init` inside `custom_environments/<env>/nix/` and commit the
-   files there works.)
-2. **Override public option values with `lib.mkForce`.** If you set an option
-   that a layer below (base, `all`, or the public profile you imported) already
-   set to a different scalar value, wrap your value with `lib.mkForce`.
-   Without it, home-manager's module system reports a conflict. (Example: the
-   `all` layer sets `programs.starship.settings = { };` (opt in to defaults);
-   a private profile that wants a custom starship layout uses
-   `programs.starship.settings = lib.mkForce { add_newline = false; … };`.)
+1. **The `public` input is auto-redirected to your local source.** `lib/nix`
+   builds the private flake with `--override-input public path:…/nix`, so
+   day-to-day builds use the current local public tree (including its untracked
+   `host.nix`), not the published GitHub repo the flake declares. Give the
+   private flake its own `flake.lock` and commit it to pin its input
+   revisions.
+2. **Override public scalars with `lib.mkForce`.** Setting an option a lower
+   layer already set to a different scalar reports a module conflict without it.
+   List/`lines` options (`home.packages`, `*Extra`) concatenate — no `mkForce`.
 
 Template:
 
@@ -132,11 +124,10 @@ Template:
       description = "Private profile for <env>";
 
       inputs = {
-        # Default points at the published public repo so `nix flake check`
-        # works in this private repo standalone. The dotfiles `nix` plugin
-        # overrides this to a local `path:` at apply time, so day-to-day
-        # builds use whatever local public source is current — including
-        # its untracked host.nix.
+        # A sensible default for the public source. `lib/nix` overrides it to a
+        # local `path:` at apply time, so day-to-day builds use the current
+        # local public tree — including its untracked host.nix (which the
+        # published repo does not carry, since it's generated per-host).
         public.url = "github:ianwremmel/dotfiles?dir=nix";
         nixpkgs.follows      = "public/nixpkgs";
         home-manager.follows = "public/home-manager";
@@ -161,549 +152,86 @@ Template:
         };
     }
 
-Where `./work.nix` (or any name) is a normal home-manager module living
-alongside `flake.nix` and may import siblings. Example override of a public
-option:
+`./work.nix` is a normal home-manager module living alongside `flake.nix`. It
+adds packages and overrides public options:
 
     # ./work.nix
     { lib, pkgs, ... }: {
-      # Override the empty starship settings that `all` sets, and add
-      # work-specific tools.
+      programs.git.settings.user = {
+        name  = lib.mkForce "<your name for this env>";
+        email = lib.mkForce "<your email for this env>";
+      };
       programs.starship.settings = lib.mkForce { add_newline = false; };
+      programs.zsh.initContent = '' # work-specific zsh init, concatenated '';
       home.packages = [ pkgs.awscli2 ];
-      # …more work-specific modules.
     }
 
-The private flake also has its own `flake.lock` (committed to your private
-repo) for standalone reproducibility.
-
-### Migrating a private custom environment after this slice
-
-When a slice migrates a plugin or rsync-managed file into home-manager,
-machines using a private `custom_environments/<env>/` repo need a one-time
-update: the old rsync-managed file gets superseded by the home-manager-managed
-XDG file, and any per-env overrides that used to live in the rsync'd file
-move into the private flake.
-
-For the git slice (`git` plugin + the rsync'd `.gitconfig` body):
-
-1. **Update your private flake** to add `programs.git`:
-
-       { lib, pkgs, ... }: {
-         programs.git.settings = {
-           user = {
-             name  = lib.mkForce "<your name for this env>";
-             email = lib.mkForce "<your email for this env>";
-           };
-
-           # Any env-specific git settings that used to live in your private
-           # .gitconfig — enterprise hosts, additional aliases, etc.
-           # Aliases land under `settings.alias`; raw git config sections
-           # become other top-level `settings.*` attrs. Use `lib.mkForce`
-           # only where overriding a value the public layer set.
-           # …your env's settings here…
-         };
-       }
-
-2. **Delete the rsync'd .gitconfig source from your private repo:**
-   `git rm custom_environments/<env>/home/.gitconfig` in the private repo
-   and commit. home-manager will own `~/.config/git/config` on that machine
-   after the next `./apply`, so the rsync source is no longer needed.
-
-3. **First `./apply` after this slice** runs the
-   `migrateLegacyGitConfig` activation script, which moves any pre-existing
-   `~/.gitconfig` aside to `~/.gitconfig.legacy-backup` once. No action
-   needed; mentioned so you know what the file is if you see it. You can
-   `rm ~/.gitconfig.legacy-backup` whenever you're satisfied with the
-   migration.
-
-For the commit-signing slice (`commit_signing` plugin retired;
-`programs.gpg`, `services.gpg-agent`, and
-`programs.git.settings.{user.signingkey,commit.gpgsign}` take over):
-
-1. **Update your private flake** to override the signing key
-   (and explicitly set `commit.gpgsign` if your private flake
-   doesn't import `public.homeModules.default`):
-
-       { lib, pkgs, ... }: {
-         programs.git.settings = {
-           user.signingkey = lib.mkForce "<your env's key id>";
-           # commit.gpgsign already inherited from `default` if your
-           # private flake imports `public.homeModules.default`;
-           # otherwise:
-           # commit.gpgsign = lib.mkForce true;
-         };
-       }
-
-2. **Nothing to delete from your private repo this time.** The old
-   `commit_signing` plugin lived only in the public repo (no rsync
-   source under `custom_environments/<env>/home/`).
-
-3. **First `./apply` after this slice** runs the
-   `migrateLegacyGnupgConfig` activation script, which moves any
-   pre-existing real `~/.gnupg/gpg.conf` and `~/.gnupg/gpg-agent.conf`
-   aside to `.legacy-backup` siblings once. No action needed; `rm ~/.gnupg/gpg.conf.legacy-backup ~/.gnupg/gpg-agent.conf.legacy-backup` when satisfied. Your actual keyring (`pubring.kbx`,
-   `private-keys-v1.d/`, `trustdb.gpg`, etc.) is never touched.
-
-For the shells slice (`shells` plugin retired; all rsync-managed shell
-dotfiles migrated; `programs.bash`, `programs.zsh`, `home.file.".inputrc"`
-and two activation scripts take over):
-
-1. **Update your private flake** to append work-specific shell content
-   (extra PATH entries, env vars, tooling init shell hooks) via the
-   `lines`-typed `*Extra` options. These CONCATENATE across layers — no
-   `lib.mkForce` needed:
-
-       { lib, pkgs, ... }: {
-         programs.zsh.initContent = ''
-           # work-specific zsh init: extra PATH entries, tooling init, …
-         '';
-         programs.bash.profileExtra = ''
-           # work-specific bash profile init: same idea
-         '';
-         home.sessionVariables = {
-           # work-specific cross-shell env vars (no overlap with public ones)
-         };
-       }
-
-2. **Delete the now-orphaned rsync sources** from your private repo:
-
-       git rm custom_environments/<env>/home/.zshrc \
-              custom_environments/<env>/home/.zshenv \
-              custom_environments/<env>/home/.zprofile \
-              custom_environments/<env>/home/.bash_profile \
-              custom_environments/<env>/home/.bashrc \
-              custom_environments/<env>/home/.profile \
-              custom_environments/<env>/home/.inputrc
-       git rm -r custom_environments/<env>/home/.zshrc.d \
-                 custom_environments/<env>/home/.bash_profile.d
-       git commit -m "remove rsync'd shell config (now managed via nix)"
-
-3. **First `./apply` after this slice** runs the `migrateLegacyShellConfig`
-   activation, which moves any pre-existing real shell dotfiles aside to
-   `.legacy-backup` siblings once, AND `chshAndEtcShells` activation, which
-   registers `~/.nix-profile/bin/zsh` in `/etc/shells` and chshes the user
-   to it (interactive sudo + password prompts in the apply terminal). The
-   second activation is interactive-tty-aware — it skips on container
-   builds and leaves its marker absent so a later interactive apply can
-   complete it. You can `rm ~/.{zshrc,zshenv,zprofile,bash_profile,bashrc,
-   profile,inputrc}.legacy-backup` and `rm -rf ~/.{zshrc,bash_profile}.d.
-   legacy-backup` whenever you're satisfied with the migration.
-
-For the prompt slice (`powerlevel` plugin retired; `.p10k.zsh` dropped;
-starship via `programs.starship.enable` takes over):
-
-1. If your private flake had a `custom_environments/<env>/home/.p10k.zsh`
-   override (none in the public template), `git rm` it from your private
-   repo and commit. Starship reads no such file; the rsync source is
-   orphaned.
-
-2. To customize starship per-environment, add to your private flake:
-
-       { lib, pkgs, ... }: {
-         programs.starship.settings = lib.mkForce {
-           # …your starship.toml content as a Nix attrset…
-         };
-       }
-
-   Use `lib.mkForce` because the public profile sets `settings = { };` —
-   the typed attrset would conflict without it. Alternatively, use
-   `lib.recursiveUpdate` if you want to merge with potential future
-   public defaults.
-
-3. **First `./apply` after this slice** runs `migrateLegacyP10kConfig`,
-   which moves any pre-existing `~/.p10k.zsh` aside to
-   `~/.p10k.zsh.legacy-backup`. The cloned `~/powerlevel10k/` repo is
-   left in place (228-entry inert directory); `rm -rf ~/powerlevel10k`
-   when satisfied. You can also `rm ~/.p10k.zsh.legacy-backup` whenever
-   you're done with the migration.
-
-For the nodejs slice (`nvm` and `node` plugins retired; fnm via
-`home.packages = [ pkgs.fnm ]` + inline `eval "$(fnm env --use-on-cd --shell …)"`
-in the bash/zsh init blocks; `home.activation.installFnmDefaultNode`
-auto-installs the LTS node on first apply):
-
-1. **No private flake changes needed** unless you want a different node
-   version or different fnm behavior. home-manager 26.05 does NOT ship a
-   typed `programs.fnm` module, so per-environment overrides are done by
-   extending the same `home.packages` and shell-init blocks the public
-   layer uses:
-
-       { lib, pkgs, ... }: {
-         # To use a different fnm build (e.g., a pinned version), add the
-         # package and your own init lines; the public layer's defaults
-         # still apply unless you remove them.
-         home.packages = [ pkgs.fnm ];
-
-         # To override the `--use-on-cd` behavior or use a different
-         # `nodeDistMirror`, set FNM_NODE_DIST_MIRROR before the init line
-         # via programs.zsh.envExtra / programs.bash.profileExtra:
-         programs.zsh.envExtra = ''
-           export FNM_NODE_DIST_MIRROR="https://your.mirror/dist/"
-         '';
-       }
-
-2. **Optional cleanup after first apply:**
-
-       rm -rf ~/.nvm           # the cloned nvm repo + installed node versions
-       brew uninstall jq       # if you don't otherwise need jq
-
-3. **To upgrade past the originally-installed LTS** (when Node 26
-   becomes LTS, etc.):
-
-       rm ~/.fnm-default-node.hm-migrated
-       ./apply
-       # OR interactively:
-       fnm install --lts
-       fnm default lts-latest
-
-4. **To pin a different default version per environment**, post-apply:
-
-       fnm install <version>
-       fnm default <version>
-
-   The marker file prevents the activation from re-overriding this.
-
-For the brew-formulas slice (most CLI formulas migrated from Brewfiles to
-`home.packages` via `nix/profiles/{all,default}/cli-tools.nix`; casks,
-mas, and taps subsequently moved to nix-darwin's `homebrew.*` options
-in the following slice):
-
-1. **Update your private flake** to add any of YOUR brew formulas that
-   have nix equivalents to `home.packages` in a private module:
-
-       { pkgs, ... }: {
-         home.packages = with pkgs; [
-           # …your private CLI tools…
-         ];
-       }
-
-2. **Delete the corresponding `brew '<name>'` lines** from your private
-   Brewfile. Keep cask, mas, and tap entries (those move in the nix-darwin
-   slice — see that slice's sub-block below).
-
-3. **First `./apply` after this slice** runs the brew step against your
-   slimmed Brewfile; `brew bundle cleanup --force` uninstalls the formulas
-   that no longer appear there, and the nix-installed versions take over
-   via PATH precedence.
-
-4. **Formulas without a nix equivalent** (e.g., custom-tap formulas from
-   work-specific taps) STAY in your private Brewfile until the nix-darwin
-   slice (next), which adds `homebrew.brews` as a declarative way to manage
-   these.
-
-5. **`bat` and `ripgrep` were proof-of-concept demo packages** added in
-   the first nix slices to prove the migration was working. They're
-   removed in this slice. If you actually want either, add them to
-   `nix/profiles/<profile>/cli-tools.nix` (or your private flake) as
-   ordinary `home.packages` entries.
-
-For the nix-darwin slice (homebrew + system-level state move into
-nix-darwin; bash plugins retire):
-
-1. **Bootstrap nix-darwin on each macOS machine** (one-time). The first
-   `./apply` after this slice detects `darwin-rebuild` is absent and
-   bootstraps automatically (sudo required; the framework's keep-alive
-   covers it). If running outside `./apply`:
-
-       sudo -H nix run nix-darwin -- switch --flake "path:$PWD/nix#default@aarch64-darwin"
-
-   Subsequent applies use `sudo -H darwin-rebuild switch --flake …`
-   automatically via the nix plugin. Note: if `/etc/shells` already
-   exists with non-nix-darwin content (e.g., from slice 6's
-   chshAndEtcShells activation), nix-darwin refuses to overwrite it.
-   Rename it once: `sudo mv /etc/shells /etc/shells.before-nix-darwin`
-   and re-run `./apply`. If you use Determinate's nix installer (the
-   default on this repo), the base config has `nix.enable = false`
-   already so nix-darwin doesn't try to manage the Nix daemon.
-
-2. **Private darwin profiles are not wired up yet.** The `nix` plugin
-   always builds nix-darwin from the public flake
-   (`darwinConfigurations.<profile>@<system>`); it does not yet check for
-   a per-env private darwin flake the way it does for home-manager. And
-   with the bash `homebrew` plugin retired, nothing in the framework
-   consumes a `Brewfile` anymore — your private
-   `custom_environments/<env>/Brewfile` is inert. Until a follow-up slice
-   adds the private-darwin branch:
-
-   - Personal-machine casks/mas/brews already live in
-     `nix/darwin/default/homebrew.nix` (public). Add additional ones
-     there if they're not sensitive.
-   - Sensitive or work-specific casks/mas/brews have NO declarative path
-     yet. Options: install them imperatively after `./apply` (knowing the
-     next apply's `cleanup = "uninstall"` will remove them again), keep
-     them as uncommitted local edits in `nix/darwin/<profile>/`, or wait
-     for the follow-up slice. `homebrew.onActivation.cleanup = "uninstall"`
-     in `nix/darwin/base.nix` removes any brew package not declared in
-     `homebrew.{casks,brews,masApps}` — there is no Brewfile escape hatch
-     anymore.
-
-3. **The `chshAndEtcShells` activation from slice 6 is gone.** nix-darwin's
-   `users.users.<name>.shell` + `environment.shells` handle login-shell
-   selection declaratively. No marker file; no interactive prompt. The
-   `~/.shells-chsh.hm-migrated` marker on existing machines is harmless
-   leftover state; you can `rm` it if you want.
-
-4. **Xcode license** is accepted automatically via
-   `system.activationScripts.xcodeLicense`. The Xcode app itself
-   installs via `homebrew.masApps.Xcode = 497799835;` in
-   `nix/darwin/base.nix`. `mas` is declared in `homebrew.brews` to
-   prevent the cleanup policy from removing it (nix-darwin doesn't
-   add `mas` implicitly as a `masApps` dependency).
-
-5. **Set iTerm's font** manually to "MesloLGS Nerd Font" once after
-   the cask installs: iTerm → Settings → Profiles → Text → Font.
-   Same for Terminal.app if you use it. The slice-11 declarative pin
-   (`com.googlecode.iterm2`/`com.apple.terminal` in `nix/darwin/defaults.nix`)
-   writes a plain-string font name, but both apps store fonts as
-   binary-encoded `NSFont` data and ignore the string form. The Nerd
-   Font cask installs to `~/Library/Fonts/` (user-level), not
-   `/Library/Fonts/`; both are visible to apps.
-
-For the nix-firstrun slice (`firstrun` plugin retired; macOS `defaults` writes migrated to nix-darwin's `system.defaults` + `CustomUserPreferences` + activation scripts):
-
-This slice migrates `environments/all/firstrun` (the macOS preferences script)
-into nix-darwin's declarative system layer. The bash framework's `firstrun`
-plugin is fully retired.
-
-**One-time apply notes:**
-
-- Mail, Safari, Messages, Photos, Activity Monitor, Address Book, Calendar,
-  Contacts, and iCal may need a one-time relaunch after this slice's first
-  `./apply` for their new preferences to take effect. nix-darwin already
-  kicks `cfprefsd`, `Dock`, `SystemUIServer`, and `Finder` automatically.
-
-- The `FIRSTRUN_APPLIED=1` entry in your `~/.dotfilesrc` is now vestigial and
-  is automatically removed by a home-manager activation on next `./apply`.
-  The rest of your config file is untouched.
-
-- iTerm and Terminal.app store font preferences as binary-encoded `NSFont`
-  data, not plain strings. The slice writes a plain-string `Normal Font` value
-  to `com.googlecode.iterm2` via `CustomUserPreferences`, but this does NOT
-  control what iTerm or Terminal.app actually use on launch (confirmed empirically).
-  The keys are preserved as a placeholder. Set the font manually: iTerm/Terminal
-  → Settings → Profiles → Text → Font → "MesloLGS Nerd Font". A follow-up slice
-  could capture the binary `NSFont` bytes from a working machine and write them
-  via `defaults write -data` to close this for real.
-
-- Contacts.app name-display preferences (`ABNameDisplay`, `ABNameSortingFormat`)
-  are NOT declaratively managed. macOS's TCC system blocks scripted writes
-  to `com.apple.addressbook` from nix-darwin's activation context. If you
-  want last-name-first sorting, set it manually in Contacts → Settings →
-  General.
-
-**Private flake update (only if you have one):**
-
-If your private flake extends `darwinConfigurations` with additional
-`system.defaults.*` or `CustomUserPreferences` entries, no changes are
-required — Nix module merging handles additive private prefs on top of the
-public baseline. If your private flake conflicts with a key set in the
-public `nix/darwin/defaults.nix`, override it with `lib.mkForce` in the
-private module.
-
-For the nix-vim slice (`vim` plugin retired; `~/.vimrc` content + plugins now home-manager managed via `programs.vim`):
-
-This slice migrates the bash `vim` plugin (which `git clone`d three pathogen
-bundles at apply time) and the rsynced `~/.vimrc` + `~/.vim/` content into
-home-manager's `programs.vim`. Plugins now come from nixpkgs at build time:
-`vim-javascript` (pangloss — replaces unmaintained `jelera/vim-javascript-syntax`),
-`vim-colors-solarized`, `editorconfig-vim`. Pathogen is no longer used; vim's
-native `packpath` mechanism handles plugin loading.
-
-home-manager's `programs.vim` does NOT create `~/.vimrc` or `~/.vim/vimrc`.
-The vimrc body lives inside the Nix store, and `~/.nix-profile/bin/vim` is a
-wrapper script that invokes vim with `-u <store-path-vimrc>`. This means
-`~/.vimrc` simply doesn't exist after this slice — editing it has no effect.
-To change vim config, edit `nix/profiles/all/vim.nix` and run `./apply`.
-
-**One-time apply notes:**
-
-- On first apply, the activation moves your existing `~/.vimrc` to
-  `~/.vimrc.legacy-backup`, `~/.vim/autoload/` (containing the old
-  `pathogen.vim`) to `~/.vim/autoload.legacy-backup/`, and `~/.vim/bundle/`
-  (the three git-cloned plugins) to `~/.vim/bundle.legacy-backup/`. Once
-  you've confirmed vim still works the way you want, you can delete the
-  `.legacy-backup` paths at your leisure.
-
-- `~/.vim/{backups,swaps,undo}/` are NOT touched by the migration. They
-  contain real vim state (backup copies of files you've edited, swap files
-  for recovery, undo history). The slice creates these directories
-  declaratively via `home.file` `.keep` placeholders so a fresh machine
-  has them, but never manages their contents.
-
-- If you had local edits to `~/.vimrc` or any of the bundle plugins, look
-  for them in the `.legacy-backup` paths and reapply manually if needed —
-  the slice's `programs.vim.extraConfig` matches the legacy `.vimrc` body
-  minus the `pathogen#infect()` line.
-
-**Private flake update (only if you have one):**
-
-If your private flake adds `programs.vim.plugins` or `programs.vim.extraConfig`
-entries, Nix module merging handles them additively on top of the public
-baseline. Conflicting keys (e.g., overriding the colorscheme) need
-`lib.mkForce` in the private module.
-
-For the nix-claude slice (`claude` plugin retired; `~/.claude/` config now home-manager managed):
-
-This slice migrates the bash `claude` plugin (which "built" `~/.claude/CLAUDE.md`
-from a renamed source then rsynced it) into home-manager. The personal Claude
-Code config — `CLAUDE.md`, `settings.json`, and `guides/` — is now managed
-declaratively in the `default` profile. `settings.json` is generated from a Nix
-attrset (`pkgs.formats.json`); `CLAUDE.md` and the guides are sourced from
-`nix/profiles/default/claude/`.
-
-**Individual files, not directories.** `~/.claude/` holds a lot of live Claude
-Code state (projects, plugins, sessions, history, auto-memory). The slice
-manages only the specific files it owns and never symlinks a whole directory,
-so your state and any ad-hoc content (e.g. a hand-written `~/.claude/commands/`
-entry) are left untouched.
-
-**Adding agents, skills, commands, or rules.** Drop a file under the matching
-directory in the repo and run `./apply`:
-
-- `nix/profiles/default/claude/agents/<name>.md` → `~/.claude/agents/<name>.md`
-- `nix/profiles/default/claude/skills/<name>/SKILL.md` → `~/.claude/skills/<name>/SKILL.md`
-- `nix/profiles/default/claude/commands/<name>.md` → `~/.claude/commands/<name>.md`
-- `nix/profiles/default/claude/rules/<name>.md` → `~/.claude/rules/<name>.md`
-
-The Nix module auto-discovers every file under those directories. The target
-dirs stay writable, so Claude-Code-authored files alongside your managed ones
-coexist.
-
-**One-time apply notes:**
-
-- On first apply, the activation moves your existing rsynced `~/.claude/CLAUDE.md`,
-  `~/.claude/settings.json`, and `~/.claude/guides/*.md` to `*.legacy-backup`
-  siblings, then home-manager links the Nix-managed versions. Delete the
-  `.legacy-backup` files once you've confirmed everything's in order.
-
-- `settings.json` is now generated from `nix/profiles/default/claude.nix`. To
-  change a setting, edit the Nix attrset and run `./apply` — editing
-  `~/.claude/settings.json` directly has no lasting effect (it's a symlink into
-  the Nix store).
-
-**Private flake update (only if you have one):**
-
-If your private flake adds `home.file.".claude/..."` entries or overrides
-settings keys, Nix module merging handles additive entries; conflicting keys
-need `lib.mkForce`.
-
-For the nix-vscode slice (`vscode` plugin retired; `code` CLI now provided by the cask):
-
-The bash `vscode` plugin only symlinked VS Code's `code` CLI helper onto PATH.
-That's now redundant: the `visual-studio-code` cask (declared in nix-darwin since
-the nix-darwin slice) lists `code` and `code-tunnel` as binary artifacts, so
-Homebrew links them into `/opt/homebrew/bin/` (on PATH) when it installs the
-cask. The plugin is deleted with no replacement — Homebrew owns the symlink.
-
-**One-time apply notes:**
-
-- No action needed. If `code` ever goes missing after a VS Code reinstall, run
-  `brew reinstall --cask visual-studio-code` to relink the binary artifacts, or
-  use VS Code's "Shell Command: Install 'code' command in PATH" from the command
-  palette.
-
-For the nix-homedir slice (`environments/all/home/` rsync content → home-manager; the homedir plugin stays for custom_environments):
-
-This slice migrates the universal rsync dotfiles into home-manager: the global
-gitignore (`programs.git.ignores`), `.screenrc` (`programs.screen`), `.gemrc` /
-`.wgetrc` / `.hushlogin` (`home.file`), the `~/bin/git-*` helper scripts
-(`home.file`, executable, per-file so `~/bin` stays writable), and `~/.ssh/config`
-(`home.file` with the macOS-only `UseKeychain` gated by platform).
-
-The `homedir` bash plugin is NOT retired — it still rsyncs
-`custom_environments/<env>/home/`. It retires in a later slice once
-custom_environments is migrated.
-
-**One-time apply notes:**
-
-- On first apply, an activation deletes the now-vestigial rsynced copies of
-  these files from `$HOME` (`.gemrc`, `.wgetrc`, `.screenrc`, `.hushlogin`,
-  `.gitignore`, `.ssh/config`, and the `~/bin/git-*` scripts) so home-manager
-  can link the managed versions. No backup is kept — they were exact copies of
-  tracked repo content. Your non-managed `~/bin` entries, `~/.ssh` keys, and
-  `known_hosts` are untouched.
-
-- The global gitignore moved from `~/.gitignore` to `~/.config/git/ignore`
-  (git reads `~/.config/git/ignore` natively as its XDG default — no
-  `core.excludesFile` needed, which is why this slice drops it). A pre-existing
-  `~/.config/git/ignore` pattern (`**/.claude/settings.local.json`) was folded
-  into `programs.git.ignores`, so it's preserved.
-
-**Private flake update (only if you have one):**
-
-If your private flake adds `home.file` entries or `programs.git.ignores`, Nix
-module merging handles additive entries; conflicting keys need `lib.mkForce`.
-
-For the nix-terminal-fonts slice (iTerm2 + Terminal.app Nerd Font, declarative):
-
-Closes the terminal-font deferral. The nix-firstrun attempt wrote a top-level
-`Normal Font` pref (ignored — the font lives per-profile) with a typo'd
-PostScript name. This slice patches the font onto your EXISTING profiles in
-place via a Python plistlib `defaults export → modify → import` round-trip
-(`nix/profiles/default/patch-terminal-fonts.py`, run from a home-manager
-activation):
-
-- **iTerm2** — the `Default` and `tmux` profiles get `Normal Font` /
-  `Non Ascii Font` set to `MesloLGSNF-Regular 14` ("MesloLGS Nerd Font").
-- **Terminal.app** — the `Homebrew` profile's `Font` (a binary NSFont blob,
-  generated once via Swift and stored with a regen comment) is set.
-
-**CONSTRAINT: quit iTerm2 and Terminal.app before `./apply`.** Both rewrite
-their prefs on quit, so a running app reverts the change. Relaunch them after
-applying to see the font. The patch is idempotent.
-
-**Changing the font:** edit `font` in `nix/profiles/default/terminal-fonts.nix`.
-For Terminal.app, also regenerate the NSFont blob (the Swift one-liner is in the
-file's comment). The font itself is installed by the `font-meslo-lg-nerd-font`
-cask (nix-darwin slice), not here.
-
-For the framework-collapse slice (the homegrown plugin framework retired; `./apply` now runs on stock Bash 3.2.57):
-
-Closes the last public-side deferral — the bash-bootstrap chicken-and-egg.
-Instead of bootstrapping a modern Bash before Nix, the plugin framework (which
-was the only thing needing Bash 4+) is collapsed: `./apply` is now a flat,
-Bash-3.2-safe script and the nix logic moved to `lib/nix`.
-`framework/{framework,plugin,util,customize}` and the `plugins/` tree are
-deleted. The per-environment `home/` rsync (the old `homedir` plugin) is also
-gone — public `home/` content already migrated to home-manager, and any
-`custom_environments/<env>/home/` content should now be managed by that env's
-private flake (`custom_environments/<env>/nix`).
-
-- **No private-flake change needed for the public profiles.** This slice
-  restructures the public bootstrap. **If your private env relied on the
-  `home/` rsync** (e.g. a `custom_environments/work/home/` overlay), move those
-  files into your private flake's `nix/files/home/` tree — `./apply` no longer
-  rsyncs them.
-- **First `./apply` after this slice:** nix-darwin's `cleanup = "uninstall"`
-  removes the now-undeclared `bash` and `bash-completion@2` Homebrew formulas.
-  General-purpose Bash 5 is provided by the nixpkgs `bash` in `home.packages`
-  (`~/.nix-profile/bin/bash`); bash completion is wired by home-manager's
-  `programs.bash.enableCompletion` (default), sourcing the nixpkgs
-  `bash-completion`. Open a fresh shell afterward and confirm `bash --version`
-  is 5.x and tab-completion still works.
-- **`custom_environments` is now cloned/updated manually** — the `customize`
-  helper that auto-cloned it was removed. `git clone` your private repo into
-  `custom_environments/` once; `./apply` discovers it from there as before.
-
-The same shape applies to future slices that migrate a plugin or rsync
-source: add the new options to your private flake, delete the now-orphaned
-rsync source from your private repo, and trust the activation cleanup.
+**Private darwin is not wired up yet.** `lib/nix` always builds nix-darwin from
+the *public* flake; it does not check for a per-env private darwin flake. With
+`homebrew.onActivation.cleanup = "uninstall"` removing any undeclared brew
+package and no Brewfile escape hatch, sensitive macOS casks/mas/brews have no
+declarative path yet — add non-sensitive ones to `nix/darwin/default/
+homebrew.nix`, or install sensitive ones imperatively (knowing the next apply
+removes them).
+
+## Migrating an existing pre-Nix machine
+
+Fresh installs need none of this — home-manager just sets everything up. It
+matters only on a machine that ran the old bash framework.
+
+**The pattern.** When a slice moves a plugin or rsync-managed file into
+home-manager, a machine with a private `custom_environments/<env>/` repo needs a
+one-time update:
+
+1. **Add the equivalent options to your private flake.** Scalar overrides use
+   `lib.mkForce`; `home.packages` / `programs.{bash,zsh}.*Extra` /
+   `programs.git.ignores` concatenate (no `mkForce`).
+2. **Delete the now-orphaned rsync source** from your private repo (e.g.
+   `git rm custom_environments/<env>/home/.gitconfig`). home-manager owns the
+   XDG-located file after the next apply.
+3. **Trust the activation cleanup, but know its two modes.** On first apply:
+   - Most migrations (git, gpg, shells, vim, claude, …) **move** the
+     pre-existing real file to a `<name>.legacy-backup` sibling, one-time. `rm`
+     the backups once satisfied.
+   - The homedir migration **deletes** its files outright with no backup —
+     these are exact copies of tracked repo content (`git` has them):
+     `.gemrc`, `.wgetrc`, `.hushlogin`, `.screenrc`, `.ssh/config`,
+     `.gitignore`, `.config/git/ignore`, and the `~/bin/git-*` helpers.
+
+   Real state — GPG keyrings, `~/.vim/{backups,swaps,undo}`, your `~/.ssh` keys,
+   `known_hosts`, other `~/bin` entries — is never touched.
+
+Operational notes that still apply steady-state:
+
+- **Terminal fonts:** quit iTerm2 and Terminal.app **before** `./apply` — both
+  rewrite prefs on quit and would revert the in-place font patch (idempotent).
+  Change the font in `nix/profiles/default/terminal-fonts.nix`.
+- **fnm / Node:** the first apply installs the current LTS once
+  (`~/.fnm-default-node.hm-migrated` marker). To move to a newer LTS later:
+  `rm ~/.fnm-default-node.hm-migrated && ./apply`, or `fnm install <v>; fnm
+  default <v>`.
+- **nix-darwin first bootstrap:** if `/etc/shells` already exists with non-
+  nix-darwin content, nix-darwin refuses to overwrite it — once:
+  `sudo mv /etc/shells /etc/shells.before-nix-darwin`, then re-`./apply`.
+- **Bash:** general-purpose Bash 5 is `~/.nix-profile/bin/bash`; the cleanup
+  policy removes the old `bash`/`bash-completion@2` Homebrew formulas on first
+  apply.
 
 ## Backout
 
-- **Disable the slice:** set `DOTFILES_NIX_SKIP=1` before `./apply`.
-- **Drop a managed file:** remove its lines from `home.nix` and re-activate;
+- **Disable Nix:** set `DOTFILES_NIX_SKIP=1` before `./apply`.
+- **Drop a managed file:** remove its lines from the module and re-activate;
   home-manager removes only symlinks it created.
-- **Remove Nix entirely:** delete `lib/nix` and `nix/`, then uninstall Nix:
-  - **macOS** (Determinate): `/nix/nix-installer uninstall`.
-  - **Linux** (official single-user): `nix-env --uninstall nix`, then
-    `rm -rf ~/.nix-profile ~/.nix-defexpr ~/.nix-channels /nix` and remove the
-    nix lines from your shell rc.
-- **Remove nix-darwin entirely:** more involved than home-manager rollback.
-  - `sudo darwin-rebuild --rollback` reverts to the previous nix-darwin generation but doesn't uninstall.
-  - To fully uninstall: `sudo /nix/var/nix/profiles/system/sw/bin/darwin-uninstaller`. This removes `/etc/static/` symlinks and the system profile; it does NOT touch your installed casks/mas (manage those via brew directly).
-  - `git revert` of this slice's commits restores the bash plugins (homebrew/homebrew_core/xcode) but does NOT revert nix-darwin's system-state changes. Manual `/etc/passwd`/`/etc/shells` cleanup may be needed (look for `/etc/shells.before-nix-darwin` — that's nix-darwin's pre-takeover backup).
+- **Remove Nix entirely:** delete `lib/nix` and `nix/`, then uninstall Nix —
+  macOS (Determinate): `/nix/nix-installer uninstall`; Linux (single-user):
+  `nix-env --uninstall nix`, then `rm -rf ~/.nix-profile ~/.nix-defexpr
+  ~/.nix-channels /nix` and strip the nix lines from your shell rc.
+- **Remove nix-darwin:** `sudo darwin-rebuild --rollback` reverts a generation;
+  full uninstall is `sudo /nix/var/nix/profiles/system/sw/bin/darwin-uninstaller`
+  (removes `/etc/static/` symlinks + the system profile; does **not** touch
+  installed casks/mas — manage those via brew). Look for
+  `/etc/shells.before-nix-darwin` (nix-darwin's pre-takeover backup) if you need
+  manual `/etc/shells` cleanup.
 
 ## License
 


### PR DESCRIPTION
## What

A comprehensive-but-succinct documentation set explaining how the repo works now that it's Nix-first (post framework-collapse). Every claim was verified against the actual code via three adversarial review passes.

### New subtree agent guides
- **`framework/CLAUDE.md`** — the Bash-3.2 bootstrap layer: the hard no-Bash-4 constraint, `apply`'s flow, each helper's job, and `lib/nix`'s install → `host.nix` → home-manager → nix-darwin sequence.
- **`nix/CLAUDE.md`** — the declarative-config map: layering model (`base` → `all` → `<profile>`; darwin `base` + `default`), a "where things go" table, and conventions (escape hatches, `cleanup="uninstall"`, the three migration styles, file-by-file `~/.claude`, `nix.enable=false`, `lib.mkForce`, pins).

### Refreshed existing docs
- **`README.md` / `CLAUDE.md`** — removed the stale `environments/` directory references (migrated into `nix/profiles/`), corrected the environment prompt/persistence behavior, noted the nix-darwin-always-`default` pin, added subtree-guide pointers, compressed the origin story.
- **`nix/README.md`** — collapsed the 510-line per-slice migration runbook into a compact "Migrating a pre-Nix machine" section (**710 → 241 lines**), preserving install steps, the profile/darwin model, the private-flake template, and backout.

## Accuracy fixes surfaced during review
- Env prompt fires when *any* env besides bare `default` exists; the selection (possibly `default`) is persisted — implicit default persists nothing.
- nix-darwin is hard-pinned to `default@<system>`; `agent` has home configs on every system but no darwin module.
- Migrations vary: marker-gated backup (git/gpg/shells), unmarked backup (vim/claude), and direct delete with no backup (home-files).
- Dropped the carried-over "`path:` needs git-tracked files" claim — it contradicted `lib/nix`'s own comment (it uses `path:` to *include* untracked `host.nix`).
- git identity + signing live in `default`, not shared `all`; documented nix-darwin's `system.stateVersion=5`.

## Notes
No code changes — docs only.