### PR TITLE
fix(claude): make ~/.claude/settings.json writable

### DIFF
--- a/nix/CLAUDE.md
+++ b/nix/CLAUDE.md
@@ -52,8 +52,14 @@ one regardless of the active profile.
   public module or install them imperatively (the cleanup policy removes any
   undeclared brew package on the next apply).
 - **Claude Code config** → `profiles/default/claude/` — files under
-  `agents/ skills/ commands/ rules/ guides/` auto-map to `~/.claude/`;
-  `settings.json` is generated from the attrset in `claude.nix`.
+  `agents/ skills/ commands/ rules/ guides/` auto-map to `~/.claude/`.
+  `settings.json` is generated from the attrset in `claude.nix`, but Claude
+  Code rewrites that file at runtime, so it can't be a read-only store symlink:
+  the `seedClaudeSettings` activation script seeds a writable copy and on later
+  applies deep-merges the Nix-declared keys over the live file (ours win;
+  Claude's `permissions.allow` and other runtime keys survive). A declared key
+  changed interactively (e.g. `defaultMode`) reverts to the Nix value on the
+  next apply.
 
 ## Conventions
 

--- a/nix/profiles/default/claude.nix
+++ b/nix/profiles/default/claude.nix
@@ -4,6 +4,30 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
+  # Static, Nix-owned Claude Code settings. Claude Code rewrites
+  # ~/.claude/settings.json at runtime (approved permissions, etc.), so the
+  # file itself can't be a read-only store symlink. These keys are seeded and
+  # then re-asserted over the live file on every apply (see seedClaudeSettings);
+  # keys Claude writes itself (permissions.allow, ...) aren't listed here and
+  # are preserved by the merge.
+  settingsDefaults = jsonFormat.generate "claude-settings.json" {
+    permissions.defaultMode = "plan";
+    hooks = {
+      Stop = [
+        { hooks = [{ type = "command"; command = "afplay -v 0.40 /System/Library/Sounds/Morse.aiff"; }]; }
+      ];
+      Notification = [
+        { hooks = [{ type = "command"; command = "afplay -v 0.35 /System/Library/Sounds/Ping.aiff"; }]; }
+      ];
+    };
+    alwaysThinkingEnabled = true;
+    sandbox = {
+      autoAllowBashIfSandboxed = true;
+      enabled = true;
+      excludedCommands = [ "git" ];
+    };
+  };
+
   # Map every regular file under ./claude/<subdir>/ to a home.file entry
   # rooted at ~/.claude/<subdir>/<relpath>. Managing individual files (not
   # whole directories) keeps ~/.claude/<subdir>/ writable and never shadows
@@ -27,24 +51,6 @@ in
   home.file =
     {
       ".claude/CLAUDE.md".source = claudeSrc + "/CLAUDE_DOT_MD.md";
-
-      ".claude/settings.json".source = jsonFormat.generate "claude-settings.json" {
-        permissions.defaultMode = "plan";
-        hooks = {
-          Stop = [
-            { hooks = [{ type = "command"; command = "afplay -v 0.40 /System/Library/Sounds/Morse.aiff"; }]; }
-          ];
-          Notification = [
-            { hooks = [{ type = "command"; command = "afplay -v 0.35 /System/Library/Sounds/Ping.aiff"; }]; }
-          ];
-        };
-        alwaysThinkingEnabled = true;
-        sandbox = {
-          autoAllowBashIfSandboxed = true;
-          enabled = true;
-          excludedCommands = [ "git" ];
-        };
-      };
     }
     // mapClaudeTree "guides"
     // mapClaudeTree "agents"
@@ -52,11 +58,36 @@ in
     // mapClaudeTree "commands"
     // mapClaudeTree "rules";
 
+  # settings.json is owned by Claude Code at runtime, so it can't be a
+  # read-only store symlink. Seed a writable copy on first activation; on
+  # subsequent applies recursively merge the Nix-owned defaults over the live
+  # file (ours wins on the static keys, Claude's permissions/runtime keys
+  # survive).
+  home.activation.seedClaudeSettings =
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      settings="$HOME/.claude/settings.json"
+      run mkdir -p "$HOME/.claude"
+      if [ -L "$settings" ] || [ ! -e "$settings" ]; then
+        # Prior store symlink or fresh install: drop in a writable copy.
+        run rm -f "$settings"
+        run install -m 0644 ${settingsDefaults} "$settings"
+      elif ${pkgs.jq}/bin/jq -e . "$settings" >/dev/null 2>&1; then
+        # Claude owns a valid file: re-assert the static keys without clobbering
+        # what Claude wrote (recursive merge; right operand wins on conflicts).
+        tmp="$settings.nix-merge"
+        ${pkgs.jq}/bin/jq -s '.[0] * .[1]' "$settings" ${settingsDefaults} > "$tmp"
+        run install -m 0644 "$tmp" "$settings"
+        run rm -f "$tmp"
+      else
+        # Unparseable JSON: replace with a clean writable copy.
+        run install -m 0644 ${settingsDefaults} "$settings"
+      fi
+    '';
+
   home.activation.migrateLegacyClaudeRsync =
     lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
       for f in \
         "$HOME/.claude/CLAUDE.md" \
-        "$HOME/.claude/settings.json" \
         "$HOME/.claude/guides/conventional-commits.md" \
         "$HOME/.claude/guides/standard-readme-spec.md"; do
         if [ -f "$f" ] && [ ! -L "$f" ]; then

--- a/nix/profiles/default/claude.nix
+++ b/nix/profiles/default/claude.nix
@@ -74,10 +74,17 @@ in
       elif ${pkgs.jq}/bin/jq -e . "$settings" >/dev/null 2>&1; then
         # Claude owns a valid file: re-assert the static keys without clobbering
         # what Claude wrote (recursive merge; right operand wins on conflicts).
-        tmp="$settings.nix-merge"
-        ${pkgs.jq}/bin/jq -s '.[0] * .[1]' "$settings" ${settingsDefaults} > "$tmp"
-        run install -m 0644 "$tmp" "$settings"
-        run rm -f "$tmp"
+        # The merge writes a temp file via redirection, which `run`/$DRY_RUN_CMD
+        # can't gate (the shell opens the redirect before the command runs), so
+        # skip the whole write under `home-manager switch -n`.
+        if [ -z "$DRY_RUN_CMD" ]; then
+          tmp="$settings.nix-merge"
+          ${pkgs.jq}/bin/jq -s '.[0] * .[1]' "$settings" ${settingsDefaults} > "$tmp"
+          install -m 0644 "$tmp" "$settings"
+          rm -f "$tmp"
+        else
+          echo "would merge ${settingsDefaults} into $settings"
+        fi
       else
         # Unparseable JSON: replace with a clean writable copy.
         run install -m 0644 ${settingsDefaults} "$settings"


### PR DESCRIPTION
A `home.file` entry symlinked `settings.json` read-only into the Nix store, but Claude Code rewrites the file at runtime (approved permissions, etc.), so every write failed.

Drop the symlink and instead seed a writable copy on activation, then deep-merge the Nix-declared keys over the live file on later applies: the static keys (`defaultMode`, `hooks`, `sandbox`, `alwaysThinkingEnabled`) win while Claude's `permissions.allow` and other runtime keys survive.