### PR TITLE
fix(nix): pass bare system as darwin flake attr ref

### DIFF
--- a/lib/nix
+++ b/lib/nix
@@ -116,6 +116,18 @@ dotfiles_nix_apply () {
   local system
   system="$(nix "${nixflags[@]}" eval --impure --raw --expr 'builtins.currentSystem')"
 
+  # Fail fast on an empty system. Every flake ref below interpolates $system as
+  # the attr key; an empty value would silently mis-target. It is especially
+  # dangerous for the nix-darwin ref (`path:...#$system`): darwin-rebuild's
+  # parser falls back to `darwinConfigurations.$(scutil --get LocalHostName)`
+  # when the fragment is empty, which could activate the wrong config without
+  # warning. currentSystem should never be empty, but guard before we build any
+  # ref from it.
+  if [ -z "$system" ]; then
+    error 'Could not determine the current system (nix eval builtins.currentSystem returned empty).'
+    return 1
+  fi
+
   # Resolve the env's flake dir by the directory rule. A private env (under
   # custom_environments) wins over a public one of the same name. Every env is
   # built against the local core via `--override-input public path:.../core`,
@@ -151,7 +163,19 @@ dotfiles_nix_apply () {
   # re-evaluating `builtins.currentSystem` via a second nix subprocess.
   if [ "$(uname -s)" = "Darwin" ]; then
     # Build the selected env's own darwin config (keyed by bare "<system>").
-    local darwin_ref="path:$flake_dir#darwinConfigurations.\"$system\""
+    # The fragment after `#` must be the BARE config name (the system, e.g.
+    # `aarch64-darwin`) — not `darwinConfigurations.<system>` and not quoted.
+    # `darwin-rebuild` (used by both the `nix run nix-darwin -- switch`
+    # bootstrap and the later `darwin-rebuild switch`) parses the ref itself:
+    # it splits on `#` with the regex `^(.*)\#([^\#\"]*)$` (whose attr class
+    # excludes `"`), then PREPENDS `darwinConfigurations.` and APPENDS `.system`
+    # to whatever it captured. So a quoted system fails the regex (→ silent
+    # fallback to `darwinConfigurations.$(hostname)`), and a `darwinConfigurations.`
+    # prefix here gets doubled. Passing the bare system lets darwin-rebuild build
+    # the correct `darwinConfigurations.<system>.system`. (The separate `nix
+    # build` comparison below is NOT darwin-rebuild, so it keeps the full quoted
+    # attr path.)
+    local darwin_ref="path:$flake_dir#$system"
 
     # `sudo -H` resets $HOME to root's home (/var/root) for the duration of
     # the elevated command. Without it, nix-darwin sees $HOME=/Users/<user>


### PR DESCRIPTION
## Summary

The first-apply nix-darwin bootstrap (`nix run nix-darwin -- switch`) and the
steady-state `darwin-rebuild switch` both go through nix-darwin's own `--flake`
ref parser, which:

1. splits the ref on `#` with the regex `^(.*)\#([^\#\"]*)$` (the attr char
   class **excludes `"`**),
2. **prepends** `darwinConfigurations.` to the captured fragment,
3. **appends** `.system`.

`lib/nix` was passing `path:$flake_dir#darwinConfigurations."$system"`. The
trailing quote makes that ref **fail the regex**, so darwin-rebuild silently
falls back to `darwinConfigurations.$(scutil --get LocalHostName).system` — a
config the flake doesn't expose — aborting the first-apply bootstrap.

This passes the **bare system** (`path:$flake_dir#$system`) so darwin-rebuild
constructs the correct `darwinConfigurations.<system>.system`. The separate
steady-state `nix build` comparison ref is **not** darwin-rebuild and parses
quoted attr paths fine, so it's deliberately left as the full quoted form.

Also adds a fail-fast guard rejecting an empty `$system` before any flake ref
is built — an empty fragment would trigger the same silent
`darwinConfigurations.$(hostname)` fallback and risk activating the wrong
config without warning (surfaced in adversarial review).

## How was it tested?

- Empirically validated on a real `./apply` on `aarch64-darwin`: before the
  fix the bootstrap errored (first a hostname-fallback attr, then a doubled
  `darwinConfigurations.` prefix during iteration); after passing the bare
  system it built `darwinConfigurations.aarch64-darwin.system` and the full
  apply completed (nix-darwin activated, `brew bundle` ran).
- Verified darwin-rebuild's parser behavior by reading the store copy of
  `darwin-rebuild.sh` and reproducing the regex/prepend/append against quoted,
  prefixed, and bare refs.
- `/bin/bash -n lib/nix` parse-check under stock macOS Bash 3.2.57.

## Notes

Surfaced while migrating `custom_environments/work` (first nix-darwin
activation on that machine), but the fix affects any first-apply nix-darwin
bootstrap. A follow-up worth considering (out of scope here): the bootstrap
resolves `nix-darwin` via the flake registry rather than core's pinned
revision — pinning it would make the bootstrap parser match steady state.