### PR TITLE
fix: dev-container first-boot failures (sandbox, activation order, secret leak)

### DIFF
--- a/environments/agent/claude.nix
+++ b/environments/agent/claude.nix
@@ -55,7 +55,9 @@ in
   # managed-settings as the system policy, so the host doesn't have to place it.
   # Self-skips when activation isn't root or the file is absent (non-Linux).
   home.activation.installAgentManagedSettings =
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    # After linkGeneration, not just writeBoundary: it copies from the
+    # ~/.config/agent/ symlink, which linkGeneration creates.
+    lib.hm.dag.entryAfter [ "linkGeneration" ] ''
       if [ "$(id -u)" = 0 ] && [ -f "$HOME/.config/agent/claude-managed-settings.json" ]; then
         run mkdir -p /etc/claude-code
         run install -m 0644 "$HOME/.config/agent/claude-managed-settings.json" \

--- a/environments/agent/sshd.nix
+++ b/environments/agent/sshd.nix
@@ -37,7 +37,9 @@ in
   # the host doesn't have to. Self-skips when activation isn't root or the file
   # is absent (non-Linux).
   home.activation.installAgentSshdDropIn =
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    # After linkGeneration, not just writeBoundary: it copies from the
+    # ~/.config/agent/sshd.conf symlink, which linkGeneration creates.
+    lib.hm.dag.entryAfter [ "linkGeneration" ] ''
       if [ "$(id -u)" = 0 ] && [ -f "$HOME/.config/agent/sshd.conf" ]; then
         run mkdir -p /etc/ssh/sshd_config.d
         run install -m 0644 "$HOME/.config/agent/sshd.conf" \

--- a/framework/config
+++ b/framework/config
@@ -14,8 +14,16 @@ config_load () {
 
   # TODO can we set IFS to ensure we only word split on X=? rather than spaces
   # and every new line?
-  # shellcheck disable=SC2046
-  IFS=$'\n' export $(grep -v '^#' "$DOTFILES_CONFIG_FILE" | xargs)
+  local _cfg
+  _cfg="$(grep -v '^#' "$DOTFILES_CONFIG_FILE" | xargs)"
+  # Guard the empty case: `export` with no arguments prints the entire
+  # environment (every `declare -x`), which dumps secrets to the log when
+  # ~/.dotfilesrc has no entries.
+  if [ -n "$_cfg" ]; then
+    # Word-split the KEY=value pairs and export each (the point of this helper).
+    # shellcheck disable=SC2086,SC2163
+    IFS=$'\n' export $_cfg
+  fi
 }
 
 config_read () {

--- a/framework/config
+++ b/framework/config
@@ -21,6 +21,12 @@ config_load () {
   # argument (values with spaces survive) and simply does nothing when empty.
   local _line
   while IFS= read -r _line; do
+    # Strip a trailing CR (CRLF-saved files) and leading whitespace before
+    # classifying, so whitespace-only lines and indented comments are skipped
+    # rather than passed to `export` — which would fail on an invalid
+    # identifier and abort apply under `set -euo pipefail`.
+    _line="${_line%$'\r'}"
+    _line="${_line#"${_line%%[![:space:]]*}"}"
     case "$_line" in '' | '#'*) continue ;; esac
     # shellcheck disable=SC2163
     export "$_line"

--- a/framework/config
+++ b/framework/config
@@ -12,18 +12,19 @@ config_load () {
 
   debug 'loading config'
 
-  # TODO can we set IFS to ensure we only word split on X=? rather than spaces
-  # and every new line?
-  local _cfg
-  _cfg="$(grep -v '^#' "$DOTFILES_CONFIG_FILE" | xargs)"
-  # Guard the empty case: `export` with no arguments prints the entire
-  # environment (every `declare -x`), which dumps secrets to the log when
-  # ~/.dotfilesrc has no entries.
-  if [ -n "$_cfg" ]; then
-    # Word-split the KEY=value pairs and export each (the point of this helper).
-    # shellcheck disable=SC2086,SC2163
-    IFS=$'\n' export $_cfg
-  fi
+  # Export each non-comment KEY=value line via a while-read loop rather than
+  # `export $(grep ... | xargs)`, which had three problems: an empty/all-comment
+  # file makes grep exit 1 and aborts apply under `set -euo pipefail`; xargs
+  # collapses entries to a space-separated string that IFS splitting then
+  # mishandles for multiple keys; and a bare `export` (no args) prints the whole
+  # environment, leaking secrets to the log. The loop exports each line as one
+  # argument (values with spaces survive) and simply does nothing when empty.
+  local _line
+  while IFS= read -r _line; do
+    case "$_line" in '' | '#'*) continue ;; esac
+    # shellcheck disable=SC2163
+    export "$_line"
+  done < "$DOTFILES_CONFIG_FILE"
 }
 
 config_read () {

--- a/lib/nix
+++ b/lib/nix
@@ -73,7 +73,9 @@ _dotfiles_nix_install () {
       # has created that directory. Requires user namespaces (present on the
       # dev-container nodes).
       if ! grep -Eqs '^[[:space:]]*sandbox[[:space:]]*=' /etc/nix/nix.conf 2>/dev/null; then
-        printf 'sandbox = true\n' >> /etc/nix/nix.conf
+        # Prepend a newline so this can't concatenate onto a prior line that
+        # lacks a trailing newline (matches the build-users-group write above).
+        printf '\nsandbox = true\n' >> /etc/nix/nix.conf
       fi
     fi
     log 'Installing Nix (official single-user install, no daemon)'

--- a/lib/nix
+++ b/lib/nix
@@ -68,6 +68,13 @@ _dotfiles_nix_install () {
       if ! grep -Eqs '^[[:space:]]*build-users-group[[:space:]]*=' /etc/nix/nix.conf 2>/dev/null; then
         printf '\nbuild-users-group =\n' >> /etc/nix/nix.conf
       fi
+      # Building as root without build users still needs the sandbox: without
+      # it, builds run with HOME=/homeless-shelter and fail once a prior build
+      # has created that directory. Requires user namespaces (present on the
+      # dev-container nodes).
+      if ! grep -Eqs '^[[:space:]]*sandbox[[:space:]]*=' /etc/nix/nix.conf 2>/dev/null; then
+        printf 'sandbox = true\n' >> /etc/nix/nix.conf
+      fi
     fi
     log 'Installing Nix (official single-user install, no daemon)'
     local installer


### PR DESCRIPTION
## Motivation

In-cluster testing of the merged dev-container-on-agent-profile work (#86 + homelab #46) surfaced several first-boot failures. This fixes the three on the dotfiles side; a companion homelab PR fixes the two entrypoint-side issues (stale clone, symlink-vs-copy).

- **Nix sandbox** (`lib/nix`): single-user root Nix built without a sandbox and tripped `error: home directory "/homeless-shelter" exists`. Write `sandbox = true` to `nix.conf` (user namespaces are available on the nodes). Confirmed: with this, the whole closure builds and activates.
- **Activation order** (`environments/agent/{claude,sshd}.nix`): the `/etc` drop-in activation scripts (`managed-settings`, `sshd.conf`) ran `entryAfter [ "writeBoundary" ]`, before `linkGeneration` creates the `~/.config/agent/*` symlinks they copy from — so both placements silently skipped. Now `entryAfter [ "linkGeneration" ]`.
- **Secret leak** (`framework/config`): `config_load` ran `export $(grep ... | xargs)`; with an empty `~/.dotfilesrc` that becomes bare `export`, printing every exported variable (`declare -x …`) and leaking injected secrets (AWS keys, tokens) to the apply/container logs. Guarded the empty case.

## Test plan
- `nix eval` of the `agent` profile (x86_64-linux) — passes; the `entryAfter [ "linkGeneration" ]` deps resolve.
- `framework/config`, `lib/nix`: `/bin/bash -n` (3.2 parser) + shellcheck clean.
- End-to-end validated in-cluster: with `sandbox = true` the full agent-profile + cluster-tool closure builds and activates, and (with the ordering fix) the `/etc` drop-ins are placed.