### PR TITLE
fix(shells): keep the nix profile bin on PATH in interactive shells

### DIFF
--- a/core/all/home/shells.nix
+++ b/core/all/home/shells.nix
@@ -13,6 +13,25 @@ let
     r2     = "env /usr/bin/arch -x86_64";
   };
 
+  # Re-prepend the nix profile bins to PATH for interactive shells. On Linux
+  # hosts (the dev-container), the login shell sources Debian's /etc/profile,
+  # which resets root's PATH after PAM applied the deterministic one from
+  # /etc/environment — dropping ~/.nix-profile/bin. home.sessionPath can't
+  # restore it because hm-session-vars.sh short-circuits when something pre-sets
+  # __HM_SESS_VARS_SOURCED (the entrypoint bakes it into /etc/environment). This
+  # runs unconditionally in the shell init, so bare `fnm`/`nix` resolve. Works in
+  # bash and zsh; idempotent (a no-op when the dir is already on PATH).
+  nixProfilePath = ''
+    for __d in "/nix/var/nix/profiles/default/bin" "$HOME/.nix-profile/bin"; do
+      case ":$PATH:" in
+        *":$__d:"*) ;;
+        *) [ -d "$__d" ] && PATH="$__d:$PATH" ;;
+      esac
+    done
+    export PATH
+    unset __d
+  '';
+
 in {
   # ---------- Cross-shell PATH additions ----------
   # User-private bin dirs. `~/.local/bin` is where the native Claude Code
@@ -174,6 +193,8 @@ in {
     bashrcExtra = ''
       [ -n "$PS1" ] || return
 
+      # Restore the nix profile bin to PATH (Linux only; see nixProfilePath).
+      ${lib.optionalString pkgs.stdenv.isLinux nixProfilePath}
       # ---- from .bash_profile.d/completion ----
     '' + (builtins.readFile ./bash-completion.bash) + ''
 
@@ -250,6 +271,8 @@ in {
     initContent = ''
       # ---- from .zshrc body ----
 
+      # Restore the nix profile bin to PATH (Linux only; see nixProfilePath).
+      ${lib.optionalString pkgs.stdenv.isLinux nixProfilePath}
       # extendedglob: support **/* globs
       setopt extendedglob
       # error on unmatched globs

--- a/core/all/home/shells.nix
+++ b/core/all/home/shells.nix
@@ -13,14 +13,14 @@ let
     r2     = "env /usr/bin/arch -x86_64";
   };
 
-  # Re-prepend the nix profile bins to PATH for interactive shells. On Linux
-  # hosts (the dev-container), the login shell sources Debian's /etc/profile,
-  # which resets root's PATH after PAM applied the deterministic one from
-  # /etc/environment — dropping ~/.nix-profile/bin. home.sessionPath can't
-  # restore it because hm-session-vars.sh short-circuits when something pre-sets
-  # __HM_SESS_VARS_SOURCED (the entrypoint bakes it into /etc/environment). This
-  # runs unconditionally in the shell init, so bare `fnm`/`nix` resolve. Works in
-  # bash and zsh; idempotent (a no-op when the dir is already on PATH).
+  # Re-prepend the nix profile bins to PATH for interactive shells. On Linux a
+  # login shell sources /etc/profile, which on Debian-family systems resets
+  # root's PATH to a fixed default — dropping ~/.nix-profile/bin even when it was
+  # already on PATH. home.sessionPath can't restore it when the environment
+  # already carries __HM_SESS_VARS_SOURCED, because hm-session-vars.sh then
+  # short-circuits. Prepending here in the shell init runs regardless, so bare
+  # `fnm`/`nix` resolve. Works in bash and zsh; idempotent (a no-op when the dir
+  # is already on PATH).
   nixProfilePath = ''
     for __d in "/nix/var/nix/profiles/default/bin" "$HOME/.nix-profile/bin"; do
       case ":$PATH:" in


### PR DESCRIPTION
Motivation

In the dev-container, bare `fnm` and `nix` are not found in interactive SSH shells — the fnm `--use-on-cd` hook calls bare `fnm` and errors on every `cd`.

Chain (confirmed in the live pod):
1. PAM sets PATH with `/root/.nix-profile/bin` from `/etc/environment` (entrypoint line 216).
2. The login shell then runs Debian `/etc/profile`, which resets root's PATH to the system default, dropping the nix bin.
3. `hm-session-vars.sh` only re-adds `~/bin:~/.local/bin`, and is itself short-circuited because the entrypoint bakes `__HM_SESS_VARS_SOURCED=1` into `/etc/environment`.

So `home.sessionPath` cannot fix it. Instead, prepend the nix profile bins directly in the shell init (`bashrcExtra` / zsh `initContent`), which runs after `/etc/profile` and regardless of the short-circuit. Guarded to Linux — macOS already has them first via nix-darwin — and idempotent.

Test plan

- `nix eval` of `homeConfigurations.x86_64-linux.activationPackage.drvPath` (agent profile) succeeds with the change.
- Post-merge in-cluster: `dotfiles-apply`, open a fresh login shell, confirm `command -v fnm` / `nix` resolve and `cd` into a repo no longer prints `fnm: command not found`.