### PR TITLE
docs(agent): explain how the remote-agent shims stay on PATH

### DIFF
--- a/environments/agent/remote-agent.nix
+++ b/environments/agent/remote-agent.nix
@@ -6,7 +6,11 @@ let
   # Auto-discover the shim files (the test/ dir aside) and map each to
   # ~/bin/<name>. Drop a file in ./remote-agent/ and it's installed — no edit
   # here. The shims are co-located under ~/bin so each resolves its sibling
-  # _remote-agent.sh by directory; ~/bin is on PATH via home.sessionPath.
+  # _remote-agent.sh by directory; ~/bin is declared on PATH via home.sessionPath
+  # and re-prepended in interactive shells by core/all/home/shells.nix's
+  # interactivePath (Debian's /etc/profile resets root's PATH, dropping it
+  # otherwise — which would leave these shims, and Claude's hooks that call them,
+  # unable to find each other).
   discovered = lib.listToAttrs (map
     (p:
       let name = lib.removePrefix prefix (toString p); in


### PR DESCRIPTION
Follow-up to #92. The comment in `remote-agent.nix` claimed `~/bin is on PATH via home.sessionPath`, which is only half true on the agent host: Debian's `/etc/profile` resets root's `PATH` and drops it, and `home.sessionPath` can't restore it (`hm-session-vars.sh` short-circuits on `__HM_SESS_VARS_SOURCED`). #92's `interactivePath` re-prepends `~/bin` in interactive shells; this updates the comment to point there so a future reader debugging a missing shim lands on the real mechanism.

Comment-only; no behavior change.