### PR TITLE
feat(claude): add rule on pushing feature branches to themselves

### DIFF
--- a/core/common/claude/files/rules/feature-branch-push.md
+++ b/core/common/claude/files/rules/feature-branch-push.md
@@ -1,0 +1,31 @@
+# Push feature branches to themselves, never the default branch
+
+When you open a branch for a change, a careless push can land on the default
+branch (`master`/`main`) instead of the branch you just made. On a protected
+default that fails loudly; on an unprotected one it silently commits straight to
+the trunk you were trying to avoid.
+
+The cause is the new branch's upstream pointing at the default. If you create the
+branch tracking the default — `git checkout -b foo origin/master`, or any
+`--track`/`-t` onto `origin/<default>` — its upstream is `origin/master`. With
+`push.default = upstream` (or `tracking`), `git push` and even
+`git push origin foo` then resolve the destination through that upstream and aim
+at `master`.
+
+Do this instead:
+
+- Create the branch without tracking the default. `git switch -c <branch>` from
+  your current HEAD. If you need to start from the latest default, fetch first
+  and branch with no tracking: `git fetch origin && git switch -c <branch>
+  --no-track origin/<default>`.
+- Push with an explicit source and set the branch's own upstream:
+  `git push -u origin HEAD`. HEAD resolves to the current branch and creates a
+  same-named remote branch regardless of `push.default`. When in doubt, spell
+  out both ends: `git push -u origin <branch>:<branch>`.
+- Read the push output before moving on. It must say `<branch> -> <branch>`. If
+  it says `<branch> -> master` (or `-> main`), stop — your upstream is wrong. Fix
+  it with `git branch --set-upstream-to=origin/<branch>` (or re-push with the
+  explicit `<branch>:<branch>` refspec). Never `git push --force` to get past it.
+
+Then open the PR from the branch against the default
+(`gh pr create --base <default> --head <branch>`).


### PR DESCRIPTION
Agents repeatedly hit the same failure: they open a branch, but the push lands on the default branch instead of the branch itself (it surfaced twice in the #92/#93 work). The cause is the new branch's upstream pointing at the default (`git checkout -b foo origin/master` / `--track`) combined with `push.default = upstream`, so `git push origin foo` resolves to `master`.

Adds `core/common/claude/files/rules/feature-branch-push.md` covering the cause and the fix: branch with `--no-track`, `git push -u origin HEAD`, and verify the push output reads `branch -> branch` before continuing.

Auto-loads via the rules dir (the bundle's `mapTree` symlinks `files/` into `~/.claude/`); no `CLAUDE.md` import needed, matching the `no-tombstone-comments` / `prefer-declarative-file-management` rules.