### PR TITLE
fix(pairing): connect to paired remotes as root

### DIFF
--- a/core/common/pairing/default.nix
+++ b/core/common/pairing/default.nix
@@ -18,9 +18,13 @@ let
   # remotes since they don't need to know which remote a request came from.
   primaryRemote = if cfg.remotes == [ ] then "" else builtins.head cfg.remotes;
   # One ssh Host block per paired remote: forward the agent's
-  # /run/remote-agent.sock back to this machine's local socket.
+  # /run/remote-agent.sock back to this machine's local socket. Pairing servers
+  # are agent hosts, which log in as root (server mode's sshd drop-in sets
+  # PermitRootLogin prohibit-password), so connect as root rather than the
+  # laptop's local username.
   remoteSshBlocks = lib.listToAttrs (map
     (h: lib.nameValuePair h {
+      User = "root";
       ControlMaster = "auto";
       ControlPath = "~/.ssh/cm-%C";
       RemoteForward = "/run/remote-agent.sock ${sock}";


### PR DESCRIPTION
The post-apply fan-out (and the per-remote RemoteForward) was connecting as the laptop's local username, so `ssh dev-container-dev-container` became `ian@…` and got `Permission denied (publickey)` — reported as "unreachable".

Pairing servers are agent hosts, which log in as root (server mode's sshd drop-in sets `PermitRootLogin prohibit-password`). This sets `User = root` on the generated client Host block so both the RemoteForward and the fan-out connect as root.

Verified: `root@dev-container-dev-container` authenticates; `ian@` is denied. The generated ssh block now includes `User root`.

## Test plan
- [ ] `./apply` on the laptop, then confirm the fan-out reaches the dev-container (no publickey denial) and the summary shows `ok`.