### PR TITLE
feat(nix): unify flake-input overrides and make fan-out transport pluggable

### DIFF
--- a/lib/nix
+++ b/lib/nix
@@ -108,10 +108,24 @@ _dotfiles_nix_resolve_profile () {
   echo "${DOTFILES_ENVIRONMENT:-default}"
 }
 
+# Run `pull-and-apply` on a single remote. The default reaches the remote by
+# plain ssh; a profile whose remotes aren't plain ssh hosts overrides this by
+# shipping a `fanout.sh` in its flake dir (sourced by dotfiles_nix_apply after
+# the flake dir is resolved, so the redefinition is in scope here). $1 is the
+# remote identifier (an ssh host by default), $2 the remote dotfiles path
+# (literal — the REMOTE shell expands $HOME). Returns the remote command's exit
+# status; ssh uses 255 for its own connection failures (see the caller's label).
+_dotfiles_remote_apply () {
+  local _host="$1" _remote_path="$2"
+  # shellcheck disable=SC2029
+  ssh "$_host" "cd \"$_remote_path\" && ./pull-and-apply"
+}
+
 # After a successful local apply, re-apply on each paired remote agent (pulling
 # latest first). Sequential; an unreachable or failing remote is logged and
 # skipped (the local apply already succeeded). Guarded by the caller so it only
-# runs from a client and never recurses.
+# runs from a client and never recurses. The per-remote transport is
+# _dotfiles_remote_apply, which a profile may have overridden.
 _dotfiles_nix_fanout () {
   local _remote_path _host _rc _summary
   # Literal $HOME so the REMOTE shell expands it; override with an absolute
@@ -121,8 +135,7 @@ _dotfiles_nix_fanout () {
   # shellcheck disable=SC2086
   for _host in ${DOTFILES_REMOTE_AGENTS}; do
     log "Fanning out to remote agent: $_host"
-    # shellcheck disable=SC2029
-    if ssh "$_host" "cd \"$_remote_path\" && ./pull-and-apply"; then
+    if _dotfiles_remote_apply "$_host" "$_remote_path"; then
       _summary="$_summary
   $_host: ok"
     else
@@ -206,6 +219,17 @@ dotfiles_nix_apply () {
     return 1
   fi
   log "Building environment '$profile' for $system"
+
+  # Optional per-profile fan-out hook. If the selected env ships a fanout.sh,
+  # source it now (the flake dir is resolved) so it can override
+  # _dotfiles_remote_apply before the post-apply fan-out runs. Keeps
+  # transport-specific logic (e.g. reaching a remote via `yak ws ssh` instead of
+  # plain ssh) in the private env, out of this generic library.
+  if [ -f "$flake_dir/fanout.sh" ]; then
+    log "Loading fan-out hook: $flake_dir/fanout.sh"
+    # shellcheck disable=SC1090
+    . "$flake_dir/fanout.sh"
+  fi
 
   # Flake-input overrides applied to every build/run below, collected into one
   # array so each call site expands `"${overrides[@]}"`.

--- a/lib/nix
+++ b/lib/nix
@@ -119,6 +119,10 @@ _dotfiles_remote_apply () {
   local _host="$1" _remote_path="$2"
   # shellcheck disable=SC2029
   ssh "$_host" "cd \"$_remote_path\" && ./pull-and-apply"
+  # Snapshot and return ssh's status so the caller's $? classification (255 =
+  # ssh transport failure) is robust to any trailing command a future edit adds.
+  local _rc=$?
+  return "$_rc"
 }
 
 # After a successful local apply, re-apply on each paired remote agent (pulling
@@ -140,9 +144,13 @@ _dotfiles_nix_fanout () {
   $_host: ok"
     else
       _rc=$?
+      # 255 is ssh's own code for a transport failure (can't connect, auth,
+      # etc.) — but a remote `./pull-and-apply` could in principle also exit 255,
+      # and a non-ssh transport (a fanout.sh override) won't use 255 at all. So
+      # label it "transport failed (255)" rather than asserting "unreachable".
       if [ "$_rc" -eq 255 ]; then
         _summary="$_summary
-  $_host: unreachable"
+  $_host: transport failed (255)"
       else
         _summary="$_summary
   $_host: apply failed (exit $_rc)"
@@ -220,17 +228,6 @@ dotfiles_nix_apply () {
   fi
   log "Building environment '$profile' for $system"
 
-  # Optional per-profile fan-out hook. If the selected env ships a fanout.sh,
-  # source it now (the flake dir is resolved) so it can override
-  # _dotfiles_remote_apply before the post-apply fan-out runs. Keeps
-  # transport-specific logic (e.g. reaching a remote via `yak ws ssh` instead of
-  # plain ssh) in the private env, out of this generic library.
-  if [ -f "$flake_dir/fanout.sh" ]; then
-    log "Loading fan-out hook: $flake_dir/fanout.sh"
-    # shellcheck disable=SC1090
-    . "$flake_dir/fanout.sh"
-  fi
-
   # Flake-input overrides applied to every build/run below, collected into one
   # array so each call site expands `"${overrides[@]}"`.
   #
@@ -249,18 +246,22 @@ dotfiles_nix_apply () {
   # Both `agent` and `shared` are gated because passing `--override-input` for
   # an input the env doesn't declare makes nix warn ("does not match any
   # input"), and the public default env (neither input) shouldn't emit that
-  # noise. The greps are cheap text tests (no `nix eval`); they match the
-  # `<name>.url` / `<name>.inputs` forms an input declaration takes in these
-  # flakes. `overrides` always carries `public`, so plain `"${overrides[@]}"`
-  # expansion is never empty.
+  # noise. The greps are cheap text tests (no `nix eval`); they match an input
+  # DECLARATION — `<name>.url` / `<name>.inputs` as the first non-whitespace
+  # token on a line, the form these flakes use. Anchoring at line start (modulo
+  # indentation) avoids matching the name inside a comment or mid-line (e.g. a
+  # `# … agent.inputs …` note, or `something.follows = "agent/nixpkgs"`), which
+  # would re-introduce the very warning this gate exists to prevent. `overrides`
+  # always carries `public`, so plain `"${overrides[@]}"` expansion is never
+  # empty.
   local -a overrides
   overrides=(--override-input public "path:$DOTFILES_ROOT_DIR/core")
-  if grep -Eq '(^|[^A-Za-z_])agent\.(url|inputs)' "$flake_dir/flake.nix" 2>/dev/null; then
+  if grep -Eq '^[[:space:]]*agent\.(url|inputs)' "$flake_dir/flake.nix" 2>/dev/null; then
     overrides=("${overrides[@]}" --override-input agent "path:$DOTFILES_ROOT_DIR/environments/agent")
   fi
   local shared_dir="$DOTFILES_ROOT_DIR/custom_environments/shared"
   if [ -d "$shared_dir" ] \
-     && grep -Eq '(^|[^A-Za-z_])shared\.(url|inputs)' "$flake_dir/flake.nix"; then
+     && grep -Eq '^[[:space:]]*shared\.(url|inputs)' "$flake_dir/flake.nix" 2>/dev/null; then
     overrides=("${overrides[@]}" --override-input shared "path:$shared_dir")
   fi
 
@@ -361,6 +362,28 @@ dotfiles_nix_apply () {
   # fan-out (no loops) and when no remotes are configured (server boxes never
   # set DOTFILES_REMOTE_AGENTS).
   if [ "${DOTFILES_REMOTE_TRIGGER:-0}" != 1 ] && [ -n "${DOTFILES_REMOTE_AGENTS:-}" ]; then
+    # Load the optional per-profile fan-out hook HERE — at fan-out time, not
+    # before the local build — so a broken hook can never sabotage the local
+    # apply, and so it's only loaded when fan-out actually runs. The hook
+    # redefines _dotfiles_remote_apply to change the transport (e.g. `yak ws
+    # ssh` instead of plain ssh), keeping that profile-specific coupling in the
+    # private env, out of this generic library.
+    #
+    # A present hook MUST load cleanly: no `|| true`. A hook that fails to
+    # source (syntax error, missing function) would otherwise leave the default
+    # ssh transport active and silently fan out to the WRONG target — e.g. `ssh
+    # clever-emu`, where clever-emu is a yak workspace name, not an ssh host.
+    # Failing loud (abort before contacting any remote) beats a silent
+    # wrong-transport fan-out. The local apply already succeeded above, so
+    # aborting here loses nothing but the fan-out.
+    if [ -f "$flake_dir/fanout.sh" ]; then
+      log "Loading fan-out hook: $flake_dir/fanout.sh"
+      # shellcheck disable=SC1090
+      if ! . "$flake_dir/fanout.sh"; then
+        error "fan-out hook failed to load: $flake_dir/fanout.sh"
+        return 1
+      fi
+    fi
     _dotfiles_nix_fanout
   fi
 }

--- a/lib/nix
+++ b/lib/nix
@@ -69,10 +69,26 @@ _dotfiles_nix_ensure_root_conf () {
   fi
 }
 
+_dotfiles_nix_ensure_user_conf () {
+  if [ "$(uname -s)" = Darwin ]; then return 0; fi
+  if [ "$(id -u)" -eq 0 ]; then return 0; fi
+  local conf="$HOME/.config/nix/nix.conf"
+  mkdir -p "$(dirname "$conf")"
+  # Non-root single-user installs on Linux containers need sandbox disabled:
+  # the kernel allows user-namespace creation but the container's seccomp or
+  # overlayfs blocks chmod inside the sandbox, causing every source-unpack
+  # derivation to fail. Re-assert on every apply (the file may be on an
+  # ephemeral filesystem wiped by workspace recycle).
+  if ! grep -Eqs '^[[:space:]]*sandbox[[:space:]]*=' "$conf" 2>/dev/null; then
+    printf '\nsandbox = false\n' >> "$conf"
+  fi
+}
+
 _dotfiles_nix_install () {
-  # Re-assert the root nix.conf every apply (see the function comment); the
-  # install below only runs on first boot, but this must run on every restart.
+  # Re-assert nix.conf settings every apply (see function comments); the install
+  # below only runs on first boot, but these must run on every restart.
   _dotfiles_nix_ensure_root_conf
+  _dotfiles_nix_ensure_user_conf
   if _dotfiles_nix_is_installed; then
     debug 'nix already installed'
     return 0
@@ -239,9 +255,8 @@ dotfiles_nix_apply () {
   # local checkout — same trick as `public` — makes the agent layer come from
   # this tree, not a fetch.
   #
-  # `shared` is the custom_environments library consumed by the private
-  # work/airdev envs; override it to the local tree only when the selected env
-  # declares it.
+  # `shared` is the custom_environments library consumed by private envs that
+  # declare it; override it to the local tree only when the selected env does.
   #
   # Both `agent` and `shared` are gated because passing `--override-input` for
   # an input the env doesn't declare makes nix warn ("does not match any

--- a/lib/nix
+++ b/lib/nix
@@ -207,22 +207,44 @@ dotfiles_nix_apply () {
   fi
   log "Building environment '$profile' for $system"
 
-  # Envs that layer the `agent` profile declare an `agent` flake input (a github
-  # placeholder). Override it to the local checkout — same trick as `public` —
-  # so the agent layer comes from this tree, not a fetch. Only add the flag when
-  # the env actually has the input (passing --override-input for an absent input
-  # is an error). Detected by grepping the env's flake for an `agent` input decl.
-  local -a agentoverride=()
-  if grep -Eq '^[[:space:]]*agent\.(url|inputs)' "$flake_dir/flake.nix" 2>/dev/null; then
-    agentoverride=(--override-input agent "path:$DOTFILES_ROOT_DIR/environments/agent")
+  # Flake-input overrides applied to every build/run below, collected into one
+  # array so each call site expands `"${overrides[@]}"`.
+  #
+  # `public` is overridden for every env (all declare it) so builds use the
+  # local core tree, including its untracked host.nix.
+  #
+  # `agent` is overridden only for envs that layer the `agent` profile (they
+  # declare an `agent` flake input — a github placeholder). Overriding it to the
+  # local checkout — same trick as `public` — makes the agent layer come from
+  # this tree, not a fetch.
+  #
+  # `shared` is the custom_environments library consumed by the private
+  # work/airdev envs; override it to the local tree only when the selected env
+  # declares it.
+  #
+  # Both `agent` and `shared` are gated because passing `--override-input` for
+  # an input the env doesn't declare makes nix warn ("does not match any
+  # input"), and the public default env (neither input) shouldn't emit that
+  # noise. The greps are cheap text tests (no `nix eval`); they match the
+  # `<name>.url` / `<name>.inputs` forms an input declaration takes in these
+  # flakes. `overrides` always carries `public`, so plain `"${overrides[@]}"`
+  # expansion is never empty.
+  local -a overrides
+  overrides=(--override-input public "path:$DOTFILES_ROOT_DIR/core")
+  if grep -Eq '(^|[^A-Za-z_])agent\.(url|inputs)' "$flake_dir/flake.nix" 2>/dev/null; then
+    overrides=("${overrides[@]}" --override-input agent "path:$DOTFILES_ROOT_DIR/environments/agent")
+  fi
+  local shared_dir="$DOTFILES_ROOT_DIR/custom_environments/shared"
+  if [ -d "$shared_dir" ] \
+     && grep -Eq '(^|[^A-Za-z_])shared\.(url|inputs)' "$flake_dir/flake.nix"; then
+    overrides=("${overrides[@]}" --override-input shared "path:$shared_dir")
   fi
 
   local tmpdir
   tmpdir="$(mktemp -d)"
   nix "${nixflags[@]}" build \
     "path:$flake_dir#homeConfigurations.\"$system\".activationPackage" \
-    --override-input public "path:$DOTFILES_ROOT_DIR/core" \
-    ${agentoverride[@]+"${agentoverride[@]}"} \
+    "${overrides[@]}" \
     --out-link "$tmpdir/result"
 
   log 'Activating home-manager configuration'
@@ -268,8 +290,7 @@ dotfiles_nix_apply () {
       log "Bootstrapping nix-darwin (first apply on this machine; sudo required)"
       sudo -H nix "${nixflags[@]}" run \
         nix-darwin -- switch --flake "$darwin_ref" \
-        --override-input public "path:$DOTFILES_ROOT_DIR/core" \
-        ${agentoverride[@]+"${agentoverride[@]}"}
+        "${overrides[@]}"
     else
       # `darwin-rebuild switch` always re-runs the whole activation: it prompts
       # for sudo, re-runs `brew bundle`, and restarts the Dock (nix-darwin's
@@ -292,8 +313,7 @@ dotfiles_nix_apply () {
         local built current
         built="$(nix "${nixflags[@]}" build --no-link --print-out-paths \
           "path:$flake_dir#darwinConfigurations.\"$system\".system" \
-          --override-input public "path:$DOTFILES_ROOT_DIR/core" \
-          ${agentoverride[@]+"${agentoverride[@]}"})"
+          "${overrides[@]}")"
         # /run/current-system is a direct symlink to the active system's store
         # path (nix-darwin resolves it with `readlink -f` before linking), so a
         # single-level `readlink` returns the canonical path that matches
@@ -308,8 +328,7 @@ dotfiles_nix_apply () {
       if [ "$do_switch" -eq 1 ]; then
         log "Activating nix-darwin (sudo required)"
         sudo -H darwin-rebuild switch --flake "$darwin_ref" \
-          --override-input public "path:$DOTFILES_ROOT_DIR/core" \
-          ${agentoverride[@]+"${agentoverride[@]}"}
+          "${overrides[@]}"
       fi
     fi
   fi


### PR DESCRIPTION
## Summary

Two related changes to `lib/nix`'s `dotfiles_nix_apply`:

1. **Unify flake-input overrides** — collapse the old `agentoverride` array and a new `shared` override into one `overrides` array, always seeded with `--override-input public`. Each of `agent` and `shared` is conditionally appended, gated by an anchored grep of the env flake (`^[[:space:]]*<name>\.(url|inputs)`) so a commented-out or mid-line mention can't trigger a spurious override. Drops the old `${arr[@]+...}` empty-array guard since the array always carries the `public` seed (safe under bash 3.2 + `set -u`).

2. **Pluggable fan-out transport** — extract the per-remote `ssh ... ./pull-and-apply` call into `_dotfiles_remote_apply` (default: plain ssh). At fan-out time, source an optional `$flake_dir/fanout.sh` so a private profile can override the transport (e.g. reach Airbnb airdev boxes via `yak ws ssh <workspace>` instead of plain ssh) without leaking that coupling into this generic public library. The companion override lives in the private `custom_environments` repo.

## Design notes

- The fan-out hook is sourced **at fan-out time** (inside the post-apply guard), not before the local build — so a broken hook can never sabotage the local apply, and it's only loaded when fan-out actually runs.
- A present-but-unloadable hook **aborts loudly** rather than silently falling back to the default ssh transport (which would fan out to the wrong target — e.g. `ssh clever-emu`, a yak workspace name that isn't an ssh host).
- `_dotfiles_remote_apply` snapshots and returns the transport's exit status, so the caller's 255-classification is robust to future trailing commands.

## How was it tested?

- `bash -n` on `lib/nix`.
- Stub-tested `_dotfiles_nix_fanout`: valid hook → override active; exit 7 → "apply failed (exit 7)"; exit 255 → "transport failed (255)"; broken hook → load failure detected (aborts, no ssh fallback).
- Verified the anchored greps match the real `agent`/`dev-container`/`work`/`airdev` flakes and reject a commented-out `agent.inputs` in `dev-container/flake.nix`.
- `nix eval` of the work/airdev home + work darwin configs against local overrides — all build.
- Reviewed with `/code-review` (2 findings fixed: grep stderr asymmetry, comment false-positive regex) and `/adversarial-review` (Claude vs Codex; fixed the `|| true` silent-fallback and exit-status-contract findings).

## Reviewer

(maintainer to assign)