### PR TITLE
fix(ssh): make ~/.ssh/config writable via an Include fragment

### DIFF
--- a/core/all/home/bash-completion.bash
+++ b/core/all/home/bash-completion.bash
@@ -1,6 +1,7 @@
-# Add tab completion for SSH hostnames based on ~/.ssh/config, ignoring
-# wildcards
-[ -e "$HOME/.ssh/config" ] && complete -o "default" -o "nospace" -W "$(grep "^Host" ~/.ssh/config | grep -v "[?*]" | cut -d " " -f2)" scp sftp ssh
+# Add tab completion for SSH hostnames from ~/.ssh/config and the managed
+# config.d/ fragment it Includes (the Host blocks live in the fragment, not the
+# top-level file), ignoring wildcards.
+[ -e "$HOME/.ssh/config" ] && complete -o "default" -o "nospace" -W "$(cat ~/.ssh/config ~/.ssh/config.d/* 2>/dev/null | grep "^Host" | grep -v "[?*]" | cut -d " " -f2)" scp sftp ssh
 
 if [ "$(uname)" == 'Darwin' ]; then
   # Add tab completion for `defaults read|write NSGlobalDomain`

--- a/core/all/home/home-files.nix
+++ b/core/all/home/home-files.nix
@@ -21,12 +21,14 @@ let
 
   # Pre-existing regular files to clear so home-manager can link. Derived from
   # the discovered set plus the specially-handled files: .screenrc (via
-  # programs.screen), .ssh/config (now owned by programs.ssh), the
-  # now-vestigial .gitignore (old excludesfile path), and .config/git/ignore
-  # (a hand-created global ignore now owned by programs.git.ignores — its sole
-  # pattern was folded into git.nix's ignores list).
+  # programs.screen), the now-vestigial .gitignore (old excludesfile path), and
+  # .config/git/ignore (a hand-created global ignore now owned by
+  # programs.git.ignores — its sole pattern was folded into git.nix's ignores
+  # list). ~/.ssh/config is deliberately absent: ssh.nix keeps it a writable
+  # real file (runtime tools rewrite it), so clearing it here would wipe a
+  # tool-injected block on every apply. ssh.nix's seed handles legacy files.
   clearPaths = (builtins.attrNames discovered)
-    ++ [ ".screenrc" ".ssh/config" ".gitignore" ".config/git/ignore" ];
+    ++ [ ".screenrc" ".gitignore" ".config/git/ignore" ];
 in
 {
   programs.screen = {

--- a/core/all/home/ssh.nix
+++ b/core/all/home/ssh.nix
@@ -1,12 +1,20 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
+let
+  # Where the managed directives land, and the Include that pulls them into the
+  # writable user config. Relative paths in an Include are resolved against
+  # ~/.ssh, so `config.d/dotfiles.conf` is ~/.ssh/config.d/dotfiles.conf.
+  fragmentRel = ".ssh/config.d/dotfiles.conf";
+  includeLine = "Include config.d/dotfiles.conf";
+in
 {
-  # ~/.ssh/config via programs.ssh.settings (freeform OpenSSH directives, keyed
-  # by host). enableDefaultConfig is off so home-manager doesn't inject its
-  # opinionated `*` defaults (Compression / ControlMaster / HashKnownHosts / …)
-  # — we declare the `*` block ourselves. Most-specific blocks first; `*` is
-  # pinned last with the DAG, since ssh takes the first value seen for each
-  # option. Other environments and the dev container merge their own entries in
-  # (e.g. a host alias, or the github bot key).
+  # Managed ~/.ssh directives (freeform OpenSSH, keyed by host).
+  # enableDefaultConfig is off so home-manager doesn't inject its opinionated `*`
+  # defaults (Compression / ControlMaster / HashKnownHosts / …) — we declare the
+  # `*` block ourselves. Most-specific blocks first; `*` is pinned last with the
+  # DAG, since ssh takes the first value seen for each option. Other environments
+  # and the dev container merge their own entries into programs.ssh.settings
+  # (e.g. a host alias, or the github bot key); all of it flows into the single
+  # rendered file that we redirect to the fragment below.
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
@@ -34,4 +42,65 @@
       );
     };
   };
+
+  # ~/.ssh/config is owned by runtime tooling — some corporate SSH helpers
+  # rewrite it in place to inject per-workspace Host blocks — so it can't be a
+  # read-only store symlink (the tool's write fails with EACCES).
+  # Instead: suppress home-manager's own ~/.ssh/config link, expose the rendered
+  # directives as a read-only fragment, and seed a writable ~/.ssh/config that
+  # Includes the fragment. The fragment refreshes from Nix on every apply; the
+  # writable config is touched only to ensure the Include is present, so we never
+  # clobber a tool-injected block.
+  home.file.".ssh/config".enable = lib.mkForce false;
+  home.file.${fragmentRel}.source = config.home.file.".ssh/config".source;
+
+  # Seed after linkGeneration, so the fragment symlink the Include points at is
+  # already in place (an interrupted earlier step never leaves us Including a
+  # missing file). Idempotent — acts only on the old read-only store symlink or
+  # a missing file (seed fresh), or a real file lacking our Include (prepend).
+  # A real config left by a runtime tool is preserved: we add the Include,
+  # never clear it. The Include goes FIRST: ssh takes the first value seen per
+  # option, so our managed directives (the no-auto-trust StrictHostKeyChecking
+  # block, the github.com identity) must precede any tool/hand block to stay
+  # authoritative — the same precedence the old single rendered config had.
+  home.activation.seedSshConfigInclude =
+    lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+      cfg="$HOME/.ssh/config"
+      run mkdir -p "$HOME/.ssh"
+      run chmod 0700 "$HOME/.ssh"
+      seed_fresh=
+      if [ -L "$cfg" ]; then
+        # Only the old read-only store symlink is ours to replace. A symlink
+        # pointing anywhere else is a deliberate user setup — leave it untouched.
+        case "$(readlink "$cfg")" in
+          /nix/store/*) seed_fresh=1 ;;
+          *) ;;
+        esac
+      elif [ ! -e "$cfg" ]; then
+        seed_fresh=1
+      fi
+      if [ -n "$seed_fresh" ]; then
+        run rm -f "$cfg"
+        if [ -z "$DRY_RUN_CMD" ]; then
+          printf '%s\n' '${includeLine}' > "$cfg"
+          chmod 0600 "$cfg"
+        else
+          echo "would seed $cfg with '${includeLine}'"
+        fi
+      elif [ -f "$cfg" ] && ! grep -qxF '${includeLine}' "$cfg"; then
+        # Pre-existing real config (tool- or hand-managed): prepend the Include
+        # so the managed directives win first-match, without disturbing the
+        # existing content. cat-into-place keeps the file's inode/owner/mode;
+        # then strip group/world write in case a tool created it loosely.
+        if [ -z "$DRY_RUN_CMD" ]; then
+          tmp="$cfg.nix-seed"
+          { printf '%s\n\n' '${includeLine}'; cat "$cfg"; } > "$tmp"
+          cat "$tmp" > "$cfg"
+          rm -f "$tmp"
+          chmod go-w "$cfg"
+        else
+          echo "would prepend '${includeLine}' to $cfg"
+        fi
+      fi
+    '';
 }


### PR DESCRIPTION
## Summary

`programs.ssh.settings` rendered `~/.ssh/config` as a read-only (0444) store
symlink in the shared `all/home` layer, so every environment got a read-only
config. Runtime tools that rewrite it in place — some corporate SSH helpers
inject per-workspace `Host` blocks — fail with EACCES, since the write lands on
a read-only store path.

The fix stops owning the top-level file while keeping the declarative directives:

- Render the managed directives to a read-only fragment at
  `~/.ssh/config.d/dotfiles.conf`, reusing home-manager's own rendered output so
  every contributor (the dev-container `github.com` bot key, the pairing
  `RemoteForward` blocks) still flows in.
- Disable home-manager's own `~/.ssh/config` link.
- Seed a writable `~/.ssh/config` that `Include`s the fragment. The Include is
  written first so the managed directives keep first-match-wins precedence over
  any tool-injected block. A pre-existing real config is preserved (Include
  prepended, never cleared); only the old store symlink or a missing file is
  replaced.
- Drop `.ssh/config` from `clearLegacyHomedirFiles`' `clearPaths` so the seeded
  real file survives each apply.
- Teach ssh-hostname bash completion to read the `config.d` fragment where the
  `Host` blocks now live.

Lifts the per-machine `seedWritableSshConfig` workaround out of the private work
env into core.

## Test plan

- `nix eval` / `nix build` confirm: the fragment renders all merged settings
  (including the dev-container `github.com` bot key and the pairing
  RemoteForward), `config.home.file.".ssh/config".source` still resolves with
  `enable = false`, and the activation script renders correctly.
- Not yet exercised live: the prepend branch against a pre-existing real config,
  and the `chmod go-w` perms repair. Needs a real `./apply` on a host whose
  `~/.ssh/config` is rewritten by external tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)