### PR TITLE
feat(dev-container): add bubblewrap and socat for Claude Code sandbox

### DIFF
--- a/environments/dev-container/dev-container.nix
+++ b/environments/dev-container/dev-container.nix
@@ -47,6 +47,10 @@ in
     bats
     mcp-grafana
     awscli2 # also used by the cluster-credential activation script
+    # Claude Code's Linux sandbox helpers. Without bwrap (bubblewrap) and socat
+    # the agent falls back to running unsandboxed in the pod.
+    bubblewrap # provides `bwrap`
+    socat
   ];
 
   home.file.".config/agent/mcp-servers-homelab.json".source = grafanaMcp;


### PR DESCRIPTION
Claude Code runs unsandboxed in the dev-container pod because its Linux sandbox
helpers aren't installed: `bwrap` (bubblewrap) and `socat` are both absent from
the pod (verified 2026-07-07). `nix` itself is healthy — cache substitution
works and `sandbox = true` — so this is about agent tooling, not nix.

This adds `bubblewrap` and `socat` to the dev-container `home.packages`.

After merge + `dotfiles-apply` in the pod: confirm `command -v bwrap socat` and
that Claude Code's sandbox mode works (run a sandboxed bash command). The
"dev-container Claude runs unsandboxed" policy can then be revisited — it was
set when sandboxing wasn't possible.

Follow-up tracked in homelab `docs/migration-followups.md` (item 2).