### PR TITLE
fix(nix): force sandbox=true after installer so fresh first-boot ./apply builds sandboxed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 custom_environments
 
 .claude/settings.local.json
+.claude/worktrees/
+
+# JetBrains IDE settings (machine-local)
+.idea/

--- a/apply
+++ b/apply
@@ -38,7 +38,7 @@ if [ "$(uname -s)" = Darwin ]; then
   compat_ensure_homebrew
 fi
 
-# Install nix, generate nix/host.nix, build + activate home-manager, and (on
+# Install nix, generate core/host.nix, build + activate home-manager, and (on
 # macOS) activate nix-darwin.
 dotfiles_nix_apply
 

--- a/lib/nix
+++ b/lib/nix
@@ -52,21 +52,22 @@ _dotfiles_nix_ensure_root_conf () {
   if [ "$(uname -s)" = Darwin ]; then return 0; fi
   if [ "$(id -u)" -ne 0 ]; then return 0; fi
   mkdir -p /etc/nix
-  # Match only a real (uncommented) assignment so a commented-out example line
-  # doesn't suppress the write; prepend a newline so the setting can't
-  # concatenate onto a prior line that lacks a trailing newline.
+  # Force build-users-group= and sandbox=true, OVERRIDING whatever the Nix
+  # installer wrote. The installer rewrites /etc/nix/nix.conf after this ran at
+  # first-boot and may set sandbox=false (or omit it), which makes the FIRST
+  # home-manager build run impure with HOME=/homeless-shelter; parallel builds
+  # then collide on that dir and ./apply aborts. A skip-if-present guard is not
+  # enough (it respects the installer's value), so strip any existing
+  # assignments and append ours — authoritative on every apply. This function is
+  # therefore also called immediately after the installer runs (below), before
+  # the first build.
   #
   # build-users-group empty: build as root rather than via the absent nixbld
-  # group. sandbox: building as root without build users still needs the
-  # sandbox, or builds run with HOME=/homeless-shelter and fail once a prior
-  # build has created that directory. Requires user namespaces (present on the
-  # dev-container nodes).
-  if ! grep -Eqs '^[[:space:]]*build-users-group[[:space:]]*=' /etc/nix/nix.conf 2>/dev/null; then
-    printf '\nbuild-users-group =\n' >> /etc/nix/nix.conf
-  fi
-  if ! grep -Eqs '^[[:space:]]*sandbox[[:space:]]*=' /etc/nix/nix.conf 2>/dev/null; then
-    printf '\nsandbox = true\n' >> /etc/nix/nix.conf
-  fi
+  # group. sandbox true: building as root without build users still needs the
+  # sandbox. Requires user namespaces (present on the dev-container nodes).
+  local conf=/etc/nix/nix.conf
+  [ -f "$conf" ] && sed -i -E '/^[[:space:]]*(build-users-group|sandbox)[[:space:]]*=/d' "$conf"
+  printf '\nbuild-users-group =\nsandbox = true\n' >> "$conf"
 }
 
 _dotfiles_nix_ensure_user_conf () {
@@ -114,6 +115,11 @@ _dotfiles_nix_install () {
     curl -fsSL https://nixos.org/nix/install -o "$installer"
     sh "$installer" --no-daemon --no-channel-add < /dev/null
     rm -f "$installer"
+    # The installer rewrites /etc/nix/nix.conf; re-assert sandbox=true now so the
+    # FIRST home-manager build (run by dotfiles_nix_apply, right after this) is
+    # sandboxed rather than impure. Without this the fresh first-boot ./apply
+    # fails on /homeless-shelter collisions.
+    _dotfiles_nix_ensure_root_conf
   fi
 }
 


### PR DESCRIPTION
On a **truly fresh** first-boot (empty /nix PVC), `./apply` aborts with `error: home directory "/homeless-shelter" exists; please remove it to assure purity of builds without sandboxing`.

Root cause: `_dotfiles_nix_ensure_root_conf` writes `sandbox = true` to `/etc/nix/nix.conf` **before** the Nix installer runs. The single-user installer then rewrites that file (setting `sandbox = false` or omitting it), and the guard `if ! grep sandbox` refuses to re-add `sandbox = true` because a sandbox line now exists. So the first `home-manager` build runs impure with `HOME=/homeless-shelter`; parallel builds collide on that dir and `./apply` aborts.

dev-container never tripped this because its /nix PVC was pre-populated — but the new coven `ai-dev` autonomous containers do a genuine fresh first-boot, which surfaced it.

Fix:
- `_dotfiles_nix_ensure_root_conf` is now authoritative: it strips any existing `build-users-group`/`sandbox` lines and appends `build-users-group =` + `sandbox = true`, overriding the installer.
- It's also called again immediately after the installer runs, before the first home-manager build.

Verified out-of-band via `NIX_CONFIG=sandbox=true` (a container-side workaround for the same issue), which made a fresh `ai-dev` pod's `./apply` succeed. This is the durable fix; the workaround can be dropped once this lands.