### PR TITLE
fix(nix): disable filter-syscalls on non-root Linux single-user installs

### DIFF
--- a/lib/nix
+++ b/lib/nix
@@ -75,13 +75,25 @@ _dotfiles_nix_ensure_user_conf () {
   if [ "$(id -u)" -eq 0 ]; then return 0; fi
   local conf="$HOME/.config/nix/nix.conf"
   mkdir -p "$(dirname "$conf")"
-  # Non-root single-user installs on Linux containers need sandbox disabled:
-  # the kernel allows user-namespace creation but the container's seccomp or
-  # overlayfs blocks chmod inside the sandbox, causing every source-unpack
-  # derivation to fail. Re-assert on every apply (the file may be on an
-  # ephemeral filesystem wiped by workspace recycle).
+  # Non-root single-user installs on Linux containers need two build-isolation
+  # knobs off. Re-assert on every apply (the file may be on an ephemeral
+  # filesystem wiped by workspace recycle).
+  #
+  # sandbox = false: the kernel allows user-namespace creation but the
+  # container's seccomp or overlayfs blocks chmod inside the sandbox, causing
+  # every source-unpack derivation to fail.
+  #
+  # filter-syscalls = false: the store lives on a bind-mounted volume whose
+  # build dir (/nix/var/nix/builds) inherits a setgid bit, and filter-syscalls'
+  # seccomp filter returns EPERM on any chmod that would set setgid. Fetchers
+  # that chmod their temp tree — nix-prefetch-git for a submoduled vim plugin,
+  # etc. — then die with "chmod: Operation not permitted" even with the sandbox
+  # already off.
   if ! grep -Eqs '^[[:space:]]*sandbox[[:space:]]*=' "$conf" 2>/dev/null; then
     printf '\nsandbox = false\n' >> "$conf"
+  fi
+  if ! grep -Eqs '^[[:space:]]*filter-syscalls[[:space:]]*=' "$conf" 2>/dev/null; then
+    printf 'filter-syscalls = false\n' >> "$conf"
   fi
 }
 


### PR DESCRIPTION
## Summary

Fresh non-root Linux workspaces failed their `./apply` while building the `editorconfig-vim` vim plugin:

```
chmod: changing permissions of '…/nix-prefetch-git-tmp-home-…': Operation not permitted
```

Root cause: these workspaces bind-mount the Nix store from `$HOME/.nix`, and the build dir (`/nix/var/nix/builds`) inherits a **setgid** bit. `filter-syscalls` (on by default) installs a seccomp filter that returns `EPERM` on any `chmod` that would set setgid. Fixed-output fetchers that chmod their temp tree — `nix-prefetch-git` for the submoduled `editorconfig-vim` — hit that filter and die, even though the sandbox is already disabled on these non-root single-user installs.

Fix: disable `filter-syscalls` alongside `sandbox` in the non-root user `nix.conf` (`_dotfiles_nix_ensure_user_conf`). Both are re-asserted on every apply, guarded so an existing value isn't clobbered.

## Test plan

Validated end-to-end on a live non-root Linux workspace:

- Reproduced the `chmod: Operation not permitted` failure on `editorconfig-vim`'s source fetch.
- Confirmed `nix show-config` already had `sandbox = false`, and `/nix/var/nix/builds` was `drwxr-sr-x` (setgid).
- Re-ran the failing fetch with `--option filter-syscalls false` → succeeded.
- Persisted `filter-syscalls = false` and re-ran the full `./apply` → completed with exit 0 (vim plugins built, home-manager generation activated).
- `/bin/bash -n lib/nix` parses clean under the Bash 3.2 constraint.