### PR TITLE
docs: add public-repo hygiene rule for custom_environments work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,20 @@ DOTFILES_DEBUG=1 ./apply  # Verbose logging
 - New configuration belongs in `core/` (shared) or `environments/<env>/`
   (per-environment), not in new shell plugins — the plugin framework was retired.
 
+## Keep the public repo public
+
+This repository is public. `custom_environments/` is a git-ignored, separate
+private repo that consumes this one. While working in `custom_environments/`
+you will discover things — bugs, missing hooks, ergonomic gaps — that call for
+a change here in the main repo. Make that change, but **never carry the private
+context across the boundary**: nothing that may be proprietary or private to
+`custom_environments/` (hostnames, machine names, employer/client names,
+internal URLs, service names, credentials, private paths, or the specifics of
+why the change was needed) may appear in a main-repo commit message, PR title
+or body, code comment, or the code itself. Describe the change on its own
+public terms — the generic capability it adds or the generic problem it fixes —
+as if it had been found without ever seeing the private config.
+
 ## Testing
 
 No automated tests. Manual testing via `./apply` (and `/bin/bash -n` parse-checks


### PR DESCRIPTION
## What

Adds a "Keep the public repo public" section to the root `CLAUDE.md` — a rule for agents (and humans) working in this repository.

## Why

Work often starts in the git-ignored, private `custom_environments/` repo and surfaces changes that belong here in the public main repo. This rule ensures that when such a change is ported over, none of the private context (hostnames, machine/employer/client names, internal URLs, service names, credentials, private paths, or the specifics of why the change was needed) leaks into main-repo commit messages, PR text, comments, or code. Changes should be described purely on their own generic, public terms.

## Notes

This is documentation only — it is a repo-authoring rule and is **not** part of the `~/.claude` bundle installed by `./apply` (that path goes through `dotfiles.claude` in the environment `.nix` files). No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnpe3AfmCtFENa7fabyh7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gnpe3AfmCtFENa7fabyh7K)_