### PR TITLE
fix(vim): use terminal vim so macOS doesn't pull XQuartz

### DIFF
--- a/core/all/home/vim.nix
+++ b/core/all/home/vim.nix
@@ -2,6 +2,12 @@
   programs.vim = {
     enable = true;
 
+    # home-manager customizes `packageConfigurable`, which defaults to
+    # `pkgs.vim-full` — the huge GTK2/X11 build that drags XQuartz onto macOS.
+    # Plain `pkgs.vim` is the terminal build (no X11), and still supports the
+    # `.customize` call the module uses for plugins/extraConfig.
+    packageConfigurable = pkgs.vim;
+
     plugins = with pkgs.vimPlugins; [
       vim-javascript          # pangloss (replaces unmaintained jelera/vim-javascript-syntax)
       vim-colors-solarized


### PR DESCRIPTION
## Problem

`vim` on macOS wanted to launch XQuartz. The installed binary was the "Huge version with GTK2 GUI" (`+X11`), and that X11 dependency is what drags XQuartz onto the machine.

## Cause

home-manager's `programs.vim` builds the customized vim by calling `.customize` on `packageConfigurable`, which defaults to `pkgs.vim-full` — the GTK2/X11 build.

## Fix

Set `programs.vim.packageConfigurable = pkgs.vim` in `core/all/home/vim.nix`. Plain `pkgs.vim` is the terminal build (no X11) and still supports the `.customize` call, so plugins and `extraConfig` are unchanged.

## Verification

Built the customized package the same way the module does. Result:

```
Huge version without GUI.  Features included (+) or not (-):
... -X11  -xterm_clipboard  +clipboard  +clipboard_provider ...
```

`nix-store -qR` on the closure contains no xquartz/xorg/gtk. Lives in `core/all/home/`, so every environment gets the terminal build.