### PR TITLE
feat(claude): configure the dispatch plugin

### DIFF
--- a/core/common/agent/claude.nix
+++ b/core/common/agent/claude.nix
@@ -70,7 +70,7 @@ in
     ".config/agent/mcp-servers.json".source = mcpServers;
   };
 
-  dotfiles.claude.settings = lib.mkIf pkgs.stdenv.isLinux dispatchCredentialMode;
+  dotfiles.claude.settings = dispatchCredentialMode;
 
   # On a privileged agent host (the dev container activates as root), install the
   # managed-settings as the system policy, so the host doesn't have to place it.

--- a/core/common/agent/claude.nix
+++ b/core/common/agent/claude.nix
@@ -2,17 +2,25 @@
 let
   jsonFormat = pkgs.formats.json { };
 
+  # An agent host drives GitHub and Linear as its own bot account, not as the
+  # operator, which is what dispatch's `dedicated` credential mode describes:
+  # posts go unwrapped and review requests can target the operator. Applied to
+  # both settings files below, since either may be the one dispatch reads.
+  dispatchCredentialMode = {
+    pluginConfigs."dispatch@agentic".options.credential_mode = "dedicated";
+  };
+
   # System-level Claude Code policy. The consuming host installs this at
   # /etc/claude-code/managed-settings.json. It pre-approves the shared plugin
   # set (see `../claude/plugins.nix`) and wires the remote-agent sound hooks (the
   # play-sound shim plays the sound on the connecting client).
   managedSettings = jsonFormat.generate "claude-managed-settings.json" (
-    (import ../claude/plugins.nix) // {
+    lib.recursiveUpdate (import ../claude/plugins.nix) (dispatchCredentialMode // {
       hooks = {
         Stop = [{ hooks = [{ type = "command"; command = "play-sound Morse 0.4"; }]; }];
         Notification = [{ hooks = [{ type = "command"; command = "play-sound Ping 0.35"; }]; }];
       };
-    }
+    })
   );
 
   # MCP servers the agent kit registers globally. The host substitutes the $VAR
@@ -61,6 +69,8 @@ in
     ".config/agent/claude-managed-settings.json".source = managedSettings;
     ".config/agent/mcp-servers.json".source = mcpServers;
   };
+
+  dotfiles.claude.settings = lib.mkIf pkgs.stdenv.isLinux dispatchCredentialMode;
 
   # On a privileged agent host (the dev container activates as root), install the
   # managed-settings as the system policy, so the host doesn't have to place it.

--- a/core/common/claude/plugins.nix
+++ b/core/common/claude/plugins.nix
@@ -32,4 +32,18 @@
     "codex@openai-codex" = true;
     "dispatch@agentic" = true;
   };
+
+  # dispatch reads these as `user_config` — `operator_login` is required, and an
+  # unattended agent has no one to answer a prompt for it. `credential_mode` is
+  # `shared` here (a personal machine drives Claude as the human) and overridden
+  # to `dedicated` for agent hosts in `../agent/claude.nix`, where the agent has
+  # its own GitHub account.
+  pluginConfigs."dispatch@agentic".options = {
+    operator_login = "ianwremmel";
+    operator_mode = "solo";
+    credential_mode = "shared";
+    copilot_available = true;
+    tracker = "linear";
+    worktree_base = "$HOME/projects/worktrees";
+  };
 }


### PR DESCRIPTION
`dispatch@agentic` is enabled in every environment but configured in none. Its
`operator_login` user_config is required, and the ai-dev pods — which now boot
into `/dispatch:orchestrate` (homelab `a74dfc8`) — have nobody to answer a
prompt for it.

`plugins.nix` gains the whole options block next to the enable flag, so both
consumers pick it up: the user `settings.json` seed and the managed-settings
policy. `credential_mode` is the one value that differs by host — a personal
machine drives Claude as the human (`shared`), an agent host acts as its own
bot account (`dedicated`) — so the agent bundle overrides it in both files.

Values match what this dev container already had configured by hand, except
`worktree_base`, which keeps its `$HOME/projects/worktrees` form, and
`team_mode`, which the plugin has since renamed to `operator_mode`.

Verified by evaluating `agent-autonomous` against the local `core`:
`config.dotfiles.claude.settings` resolves to
`{"pluginConfigs":{"dispatch@agentic":{"options":{"credential_mode":"dedicated"}}}}`.
A full build needs a Nix daemon this container doesn't have, so the generated
JSON itself is unbuilt.

Opened from a fork — `ianwremmel-ai-agent` has read-only access here.