### PR TITLE
fix(cli-tools): install terraform on macOS only

### DIFF
--- a/core/all/home/cli-tools.nix
+++ b/core/all/home/cli-tools.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ lib, pkgs, ... }: {
   # CLI tools that every machine gets. Migrated from
   # `environments/all/Brewfile` plus the non-bash aggregator entries in
   # `plugins/homebrew/Brewfile.erb` (coreutils, gh). The corresponding
@@ -36,7 +36,6 @@
     httpie
 
     # Infrastructure
-    terraform  # unfree; requires nixpkgs.config.allowUnfree = true
     tflint
 
     # Language runtimes
@@ -47,5 +46,14 @@
     bash             # general-purpose Bash 5 on PATH (~/.nix-profile/bin/bash)
     bash-completion  # nixpkgs `bash-completion` is the v2 series (brew name: bash-completion@2)
     zsh-completions
+  ] ++ lib.optionals pkgs.stdenv.isDarwin [
+    # macOS only. terraform is unfree (BSL), so cache.nixos.org carries no
+    # build and every host compiles it locally. Linux container hosts can't
+    # give nix the kernel namespaces its build sandbox needs, so that compile
+    # runs unsandboxed, and the Go toolchain writes telemetry into nix's HOME
+    # stand-in `/homeless-shelter` — whose existence makes nix abort every
+    # later unsandboxed build, breaking the whole activation. Linux hosts use
+    # `opentofu` instead. Requires nixpkgs.config.allowUnfree = true.
+    terraform
   ];
 }

--- a/core/common/agent/cli-tools.nix
+++ b/core/common/agent/cli-tools.nix
@@ -1,7 +1,8 @@
 { pkgs, lib, ... }: {
   # Agent-environment CLI tools, on top of the shared core/all set. `gh`,
-  # `awscli2`, `chamber`, and `terraform` already come from core/all, so they
-  # are not repeated here.
+  # `awscli2`, and `chamber` already come from core/all, so they are not
+  # repeated here. `terraform` does not: core/all installs it on macOS only,
+  # and Linux agent hosts use the `opentofu` below.
   home.packages = with pkgs; [
     buildkite-cli # the `bk` CLI
   ] ++ lib.optionals pkgs.stdenv.isLinux [


### PR DESCRIPTION
terraform is unfree, so cache.nixos.org has no build of it and every host compiles it locally. Linux container hosts can't give nix the kernel namespaces its build sandbox needs — nix's probe fails with `PID namespaces do not work on this system: cannot remount /proc` under a masked-path container — so the compile runs unsandboxed with `HOME=/homeless-shelter`. The Go toolchain writes telemetry into that directory, and nix then aborts every subsequent unsandboxed build because the directory exists.

The result is that a fresh `/nix` can no longer be bootstrapped on a Linux container host: `./apply` dies partway through with

    error: home directory "/homeless-shelter" exists; please remove it to assure purity of builds without sandboxing

Hit today on a new homelab `ai-dev` pod, which came up with no agent toolchain at all. Re-running `dotfiles-apply` after clearing the directory fails again at the same derivation.

Linux hosts already get `opentofu` from the agent bundle, so dropping terraform there costs nothing. macOS keeps it (nix's sandbox works there).

Verified by evaluating both configurations against this branch:

    agent-autonomous / x86_64-linux -> opentofu-1.11.8 tflint-0.61.0
    default / aarch64-darwin        -> opentofu-1.11.8 terraform-1.15.3