### PR TITLE
feat(agent-interactive): add claude-remote shim and skill

### DIFF
--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -64,10 +64,13 @@ are content-free aliases re-exporting `agent-autonomous` and
   config, personal CLI tools, terminal fonts, git identity + signing) and
   `default/darwin.nix` (personal casks/mas/brews).
 - **`agent-interactive`** — an SSH-in agent host. Home half only, Linux only:
-  the `agent` bundle, with `dotfiles.agent.reposFile` set to its `repos.txt`.
+  the `agent` bundle, with `dotfiles.agent.reposFile` set to its `repos.txt`,
+  plus `claude-remote.nix` (the `claude-remote` shim and its
+  `/dotfiles-claude-remote` skill — operator-facing, so they stay out of the
+  shared bundle).
 - **`agent-autonomous`** — an unattended agent host. The `agent` bundle with no
-  `reposFile` (a private environment supplies one). Identical to
-  `agent-interactive` but for that; Linux only, so no darwin half.
+  `reposFile` (a private environment supplies one) and none of the
+  operator-facing extras; Linux only, so no darwin half.
 
 The active environment is selected by which env flake `lib/nix` builds (from
 `DOTFILES_ENVIRONMENT`), not by a value inside `host.nix`. The untracked

--- a/environments/agent-interactive/bin/claude-remote
+++ b/environments/agent-interactive/bin/claude-remote
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# claude-remote <project> — open a Claude session with Remote Control enabled in
+# one of the repos the agent bundle clones into ~/projects, so the session can be
+# driven from claude.ai or the mobile app. The session is named `remote-<project>`
+# there.
+#
+# Runs in the foreground; to leave one running past the current shell, start it
+# under tmux (which is what the /claude-remote skill does).
+
+set -euo pipefail
+
+projects_dir="$HOME/projects"
+
+list_projects() {
+  find "$projects_dir" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null |
+    sort | tr '\n' ' '
+}
+
+usage() {
+  echo "usage: claude-remote <project>" >&2
+  echo "projects: $(list_projects)" >&2
+}
+
+project="${1-}"
+if [ -z "$project" ]; then
+  usage
+  exit 2
+fi
+
+dir="$projects_dir/$project"
+if [ ! -d "$dir" ]; then
+  echo "claude-remote: no such project: $dir" >&2
+  usage
+  exit 1
+fi
+
+cd "$dir"
+exec claude --dangerously-skip-permissions --remote-control "remote-${project}"

--- a/environments/agent-interactive/claude-remote.nix
+++ b/environments/agent-interactive/claude-remote.nix
@@ -1,0 +1,13 @@
+{ ... }:
+{
+  # `claude-remote <project>` starts a Remote Control Claude session in one of
+  # the cloned repos; the /dotfiles-claude-remote skill launches it under tmux from
+  # inside an already-running session. Interactive hosts only — an unattended
+  # host has no operator to pick the remote session up.
+  home.file.".local/bin/claude-remote" = {
+    source = ./bin/claude-remote;
+    executable = true;
+  };
+
+  dotfiles.claude.extraTrees = [ ./claude ];
+}

--- a/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
+++ b/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: dotfiles-claude-remote
+description: Start a Remote Control Claude session for one of the ~/projects repos in a detached tmux session, so it can be driven from claude.ai or the mobile app. Invoke as `/dotfiles-claude-remote <project>`.
+---
+
+# dotfiles-claude-remote
+
+Launch a second Claude session in `~/projects/$ARGUMENTS` with Remote Control
+enabled. It runs detached under tmux, so it outlives this session; it is a
+separate session, not a subagent, so nothing here can talk to it afterwards.
+
+1. Take the project name from `$ARGUMENTS`. If empty, list the directories in
+   `~/projects` and ask which one.
+2. If `~/projects/<project>` is not a directory, say so, list the available
+   projects, and stop.
+3. If `tmux has-session -t remote-<project>` succeeds, one is already running —
+   report it and stop rather than starting a second.
+4. Otherwise start it:
+
+       tmux new-session -d -s "remote-<project>" claude-remote <project>
+
+5. Report the Remote Control name (`remote-<project>`, how it appears on
+   claude.ai and mobile) and `tmux attach -t remote-<project>` for taking it
+   over from a shell here.

--- a/environments/agent-interactive/flake.nix
+++ b/environments/agent-interactive/flake.nix
@@ -3,7 +3,8 @@
 
   # Linux-only: an interactive agent host is a container you SSH into. The agent
   # bundle carries everything (cluster tooling, credential restore, cloning,
-  # tmux, the claude bundle); this environment only names the repos to clone.
+  # tmux, the claude bundle); this environment names the repos to clone and adds
+  # the operator-facing bits (./claude-remote.nix).
   inputs = {
     public.url = "github:ianwremmel/dotfiles?dir=core";
     nixpkgs.follows      = "public/nixpkgs";
@@ -27,6 +28,7 @@
               { dotfiles.agent.reposFile = ./repos.txt; }
               public.homeModules.pairing
               { dotfiles.pairing.mode = "server"; }
+              ./claude-remote.nix
             ];
           };
         })


### PR DESCRIPTION
`claude-remote <project>` cds into `~/projects/<project>` and runs

    claude --dangerously-skip-permissions --remote-control "remote-<project>"

so the session can be driven from claude.ai or the mobile app. Bad or missing
project names print the available ones.

`/claude-remote <project>` does the same from inside a running session, but
under `tmux new-session -d -s remote-<project>` — Bash can't host a TUI, and
the detached session outlives the one that started it.

Both live in `environments/agent-interactive` rather than the shared `agent`
bundle: an unattended host has no operator to pick the remote session up. The
skill reaches `~/.claude/skills/` through `dotfiles.claude.extraTrees`.

Verified by building `homeConfigurations."x86_64-linux".activationPackage`
against the local core: the generation carries `.local/bin/claude-remote`
(mode 0555) and `.claude/skills/claude-remote/SKILL.md`. `shellcheck` clean.