### PR TITLE
feat(agent): register the Outline MCP server

### DIFF
--- a/core/common/agent/claude.nix
+++ b/core/common/agent/claude.nix
@@ -42,6 +42,17 @@ let
         args = [ "stdio" ];
         env.BUILDKITE_API_TOKEN = "$BUILDKITE_API_TOKEN";
       }
+      {
+        # Self-hosted Outline's MCP endpoint. Streamable HTTP is the only
+        # transport it supports; a static Outline API key (Bearer) is the
+        # headless-friendly auth. The key is projected per pod as OUTLINE_API_KEY
+        # (homelab ESO); a pod without it just 401s here and other servers are
+        # unaffected.
+        name = "outline";
+        transport = "http";
+        url = "https://wiki.000793.xyz/mcp";
+        headers.Authorization = "Bearer $OUTLINE_API_KEY";
+      }
     ];
   };
 


### PR DESCRIPTION
Add self-hosted Outline (`wiki.000793.xyz/mcp`) to the agent kit's global MCP
list, so both the dev-container and ai-dev pods reach it. Streamable HTTP is the
only transport Outline supports; auth is a static Outline API key (Bearer),
substituted from `OUTLINE_API_KEY`.

The token half lands in homelab (already on `main`, commit `e296201`): a
dedicated ExternalSecret projects `OUTLINE_API_KEY` into each pod from the
human-maintained 1Password item `outline/ai/api-key`, consumed via an optional
`envFrom`. A pod without the key just 401s on Outline; other MCP servers are
unaffected.

Nothing to configure here beyond the server entry — the `$VAR` is substituted at
`claude mcp add` time from the pod env.