### PR TITLE
ci: run Validate on pull_request, not just push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,13 +1,19 @@
-on: push
+on:
+  push:
+  pull_request:
 name: Validate
 jobs:
   fixup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - uses: ianwremmel/prevent-fixup-commits@v1.0.1
   nopush:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - uses: ianwremmel/prevent-nopush-commits@v1.0.2


### PR DESCRIPTION
## Problem

The `Validate` workflow (`.github/workflows/push.yml`) triggers only on `push`. Its two jobs — `fixup` and `nopush` — are configured as **required status checks** in branch protection.

Because pushes to a fork's branch fire the workflow *in the fork*, not in this base repo, those checks never report on PRs opened from forks (e.g. the `ianwremmel-ai-agent` bot's PRs). The required checks stay in the "expected" state forever and the PR is permanently `blocked` from merging — even after approval. This is exactly what happened on #112, which had to be unblocked manually by pushing its head SHA to a base-repo branch to make the push-triggered workflow run.

## Fix

- Add a `pull_request` trigger so the checks run natively in the base repo for **every** PR, including those from forks (the `pull_request` event always runs in the base repo).
- Set `fetch-depth: 0` on both checkout steps. The `prevent-fixup-commits` / `prevent-nopush-commits` actions inspect `git merge-base HEAD origin/<default-branch>..HEAD`, which needs full history and the `origin/<default>` ref present — the default shallow checkout doesn't reliably provide that on `pull_request` events. (This matches the `fetch-depth: 0` shown in both actions' own READMEs.)

The `push` trigger is retained so direct pushes to `master` (e.g. squash-merge results) are still validated.

## Verification

The `fixup` and `nopush` jobs on this PR's own head commit exercise the new `pull_request` path — if they report green here, the fix works. Once this lands, future fork PRs will get the required checks automatically, no manual SHA-push workaround needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp5wRg9WDNnLYdAusyAcDa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp5wRg9WDNnLYdAusyAcDa)_