### PR TITLE
feat(claude-remote): require a session identifier and pre-accept the trust prompt

### DIFF
--- a/environments/agent-interactive/bin/claude-remote
+++ b/environments/agent-interactive/bin/claude-remote
@@ -33,7 +33,11 @@ session="$2"
 
 # Both halves are interpolated into `remote-<project>-<session>`, and tmux reads
 # `.` and `:` in a session name as window/pane addressing. Restricting each to a
-# name tmux can express also keeps `<project>` from walking out of ~/projects.
+# name tmux can express also keeps `<project>` free of path separators.
+# globasciiranges keeps the ranges below byte-based whatever the caller's locale
+# collates (it predates the Bash 5 this runs under; the guard is for the odd
+# older shell).
+shopt -s globasciiranges 2>/dev/null || true
 for arg in "$project" "$session"; do
   case "$arg" in
   '' | *[!A-Za-z0-9_-]*)
@@ -51,51 +55,4 @@ if [ ! -d "$dir" ]; then
 fi
 
 cd "$dir"
-# Claude keys its per-project state on the physical cwd it inherits, so resolve
-# symlinks the same way rather than keeping the logical path.
-dir="$(pwd -P)"
-
-# A directory Claude has never run in gets a workspace trust prompt at startup,
-# separate from --dangerously-skip-permissions and with no flag to bypass it.
-# Detached under tmux there is nobody to answer it, so accept it up front — but
-# only when the directory has no entry at all, so a previously declined project
-# stays declined. Every failure path here warns and launches anyway; a session
-# that stops at the prompt is recoverable by attaching to it.
-accept_trust_prompt() {
-  local config="${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"
-  local tmp
-
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "claude-remote: jq not on PATH; leaving the workspace trust prompt to the session" >&2
-    return 0
-  fi
-
-  # Follow a symlinked config so the rename below replaces the file jq read
-  # rather than the link pointing at it.
-  config="$(readlink -f "$config")"
-
-  if [ ! -e "$config" ]; then
-    (
-      umask 077
-      printf '{}\n' >"$config"
-    )
-  elif ! jq -e . "$config" >/dev/null 2>&1; then
-    echo "claude-remote: $config is not valid JSON; leaving the workspace trust prompt to the session" >&2
-    return 0
-  elif jq -e --arg dir "$dir" '(.projects // {}) | has($dir)' "$config" >/dev/null 2>&1; then
-    return 0
-  fi
-
-  tmp="$(mktemp "$config.XXXXXX")"
-  if jq --arg dir "$dir" '.projects[$dir].hasTrustDialogAccepted = true' "$config" >"$tmp" &&
-    mv "$tmp" "$config"; then
-    return 0
-  fi
-
-  rm -f "$tmp"
-  echo "claude-remote: could not record workspace trust in $config; the session may stop at the trust prompt" >&2
-}
-
-accept_trust_prompt
-
 exec claude --dangerously-skip-permissions --remote-control "remote-${project}-${session}"

--- a/environments/agent-interactive/bin/claude-remote
+++ b/environments/agent-interactive/bin/claude-remote
@@ -23,21 +23,25 @@ usage() {
   echo "projects: $(list_projects)" >&2
 }
 
-project="${1-}"
-session="${2-}"
-if [ -z "$project" ] || [ -z "$session" ]; then
+if [ "$#" -ne 2 ]; then
   usage
   exit 2
 fi
 
-# tmux reads `.` and `:` in a session name as window/pane addressing, so keep the
-# identifier to characters that survive both tmux and the Remote Control name.
-case "$session" in
-*[!A-Za-z0-9_-]*)
-  echo "claude-remote: session may only contain letters, digits, '_' and '-': $session" >&2
-  exit 2
-  ;;
-esac
+project="$1"
+session="$2"
+
+# Both halves are interpolated into `remote-<project>-<session>`, and tmux reads
+# `.` and `:` in a session name as window/pane addressing. Restricting each to a
+# name tmux can express also keeps `<project>` from walking out of ~/projects.
+for arg in "$project" "$session"; do
+  case "$arg" in
+  '' | *[!A-Za-z0-9_-]*)
+    echo "claude-remote: project and session may only contain letters, digits, '_' and '-': $arg" >&2
+    exit 2
+    ;;
+  esac
+done
 
 dir="$projects_dir/$project"
 if [ ! -d "$dir" ]; then
@@ -47,27 +51,49 @@ if [ ! -d "$dir" ]; then
 fi
 
 cd "$dir"
-dir="$PWD"
+# Claude keys its per-project state on the physical cwd it inherits, so resolve
+# symlinks the same way rather than keeping the logical path.
+dir="$(pwd -P)"
 
-# A directory Claude has never run in gets a workspace trust prompt at startup.
+# A directory Claude has never run in gets a workspace trust prompt at startup,
+# separate from --dangerously-skip-permissions and with no flag to bypass it.
 # Detached under tmux there is nobody to answer it, so accept it up front — but
 # only when the directory has no entry at all, so a previously declined project
-# stays declined.
+# stays declined. Every failure path here warns and launches anyway; a session
+# that stops at the prompt is recoverable by attaching to it.
 accept_trust_prompt() {
   local config="${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"
   local tmp
 
-  command -v jq >/dev/null 2>&1 || return 0
-  [ -f "$config" ] || return 0
-  jq -e --arg dir "$dir" '.projects // {} | has($dir)' "$config" >/dev/null && return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "claude-remote: jq not on PATH; leaving the workspace trust prompt to the session" >&2
+    return 0
+  fi
+
+  # Follow a symlinked config so the rename below replaces the file jq read
+  # rather than the link pointing at it.
+  config="$(readlink -f "$config")"
+
+  if [ ! -e "$config" ]; then
+    (
+      umask 077
+      printf '{}\n' >"$config"
+    )
+  elif ! jq -e . "$config" >/dev/null 2>&1; then
+    echo "claude-remote: $config is not valid JSON; leaving the workspace trust prompt to the session" >&2
+    return 0
+  elif jq -e --arg dir "$dir" '(.projects // {}) | has($dir)' "$config" >/dev/null 2>&1; then
+    return 0
+  fi
 
   tmp="$(mktemp "$config.XXXXXX")"
-  if jq --arg dir "$dir" '.projects[$dir].hasTrustDialogAccepted = true' "$config" >"$tmp"; then
-    chmod --reference="$config" "$tmp" 2>/dev/null || true
-    mv "$tmp" "$config"
-  else
-    rm -f "$tmp"
+  if jq --arg dir "$dir" '.projects[$dir].hasTrustDialogAccepted = true' "$config" >"$tmp" &&
+    mv "$tmp" "$config"; then
+    return 0
   fi
+
+  rm -f "$tmp"
+  echo "claude-remote: could not record workspace trust in $config; the session may stop at the trust prompt" >&2
 }
 
 accept_trust_prompt

--- a/environments/agent-interactive/bin/claude-remote
+++ b/environments/agent-interactive/bin/claude-remote
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# claude-remote <project> — open a Claude session with Remote Control enabled in
-# one of the repos the agent bundle clones into ~/projects, so the session can be
-# driven from claude.ai or the mobile app. The session is named `remote-<project>`
-# there.
+# claude-remote <project> <session> — open a Claude session with Remote Control
+# enabled in one of the repos the agent bundle clones into ~/projects, so the
+# session can be driven from claude.ai or the mobile app. It appears there as
+# `remote-<project>-<session>`; the session identifier is what tells concurrent
+# sessions on the same repo apart.
 #
 # Runs in the foreground; to leave one running past the current shell, start it
-# under tmux (which is what the /claude-remote skill does).
+# under tmux (which is what the /dotfiles-claude-remote skill does).
 
 set -euo pipefail
 
@@ -18,15 +19,25 @@ list_projects() {
 }
 
 usage() {
-  echo "usage: claude-remote <project>" >&2
+  echo "usage: claude-remote <project> <session>" >&2
   echo "projects: $(list_projects)" >&2
 }
 
 project="${1-}"
-if [ -z "$project" ]; then
+session="${2-}"
+if [ -z "$project" ] || [ -z "$session" ]; then
   usage
   exit 2
 fi
+
+# tmux reads `.` and `:` in a session name as window/pane addressing, so keep the
+# identifier to characters that survive both tmux and the Remote Control name.
+case "$session" in
+*[!A-Za-z0-9_-]*)
+  echo "claude-remote: session may only contain letters, digits, '_' and '-': $session" >&2
+  exit 2
+  ;;
+esac
 
 dir="$projects_dir/$project"
 if [ ! -d "$dir" ]; then
@@ -36,4 +47,29 @@ if [ ! -d "$dir" ]; then
 fi
 
 cd "$dir"
-exec claude --dangerously-skip-permissions --remote-control "remote-${project}"
+dir="$PWD"
+
+# A directory Claude has never run in gets a workspace trust prompt at startup.
+# Detached under tmux there is nobody to answer it, so accept it up front — but
+# only when the directory has no entry at all, so a previously declined project
+# stays declined.
+accept_trust_prompt() {
+  local config="${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"
+  local tmp
+
+  command -v jq >/dev/null 2>&1 || return 0
+  [ -f "$config" ] || return 0
+  jq -e --arg dir "$dir" '.projects // {} | has($dir)' "$config" >/dev/null && return 0
+
+  tmp="$(mktemp "$config.XXXXXX")"
+  if jq --arg dir "$dir" '.projects[$dir].hasTrustDialogAccepted = true' "$config" >"$tmp"; then
+    chmod --reference="$config" "$tmp" 2>/dev/null || true
+    mv "$tmp" "$config"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+accept_trust_prompt
+
+exec claude --dangerously-skip-permissions --remote-control "remote-${project}-${session}"

--- a/environments/agent-interactive/claude-remote.nix
+++ b/environments/agent-interactive/claude-remote.nix
@@ -1,9 +1,14 @@
-{ ... }:
+{ pkgs, ... }:
 {
-  # `claude-remote <project>` starts a Remote Control Claude session in one of
-  # the cloned repos; the /dotfiles-claude-remote skill launches it under tmux from
-  # inside an already-running session. Interactive hosts only — an unattended
-  # host has no operator to pick the remote session up.
+  # `claude-remote <project> <session>` starts a Remote Control Claude session in
+  # one of the cloned repos; the /dotfiles-claude-remote skill launches it under
+  # tmux from inside an already-running session. Interactive hosts only — an
+  # unattended host has no operator to pick the remote session up.
+
+  # claude-remote edits ~/.claude.json to pre-accept the workspace trust prompt;
+  # nothing else in the bundle puts jq on PATH.
+  home.packages = [ pkgs.jq ];
+
   home.file.".local/bin/claude-remote" = {
     source = ./bin/claude-remote;
     executable = true;

--- a/environments/agent-interactive/claude-remote.nix
+++ b/environments/agent-interactive/claude-remote.nix
@@ -5,8 +5,9 @@
   # tmux from inside an already-running session. Interactive hosts only — an
   # unattended host has no operator to pick the remote session up.
 
-  # claude-remote edits ~/.claude.json to pre-accept the workspace trust prompt;
-  # nothing else in the bundle puts jq on PATH.
+  # claude-remote edits Claude's own config (`$CLAUDE_CONFIG_DIR/.claude.json`,
+  # `~/.claude.json` unset) to pre-accept the workspace trust prompt; nothing
+  # else in the bundle puts jq on PATH.
   home.packages = [ pkgs.jq ];
 
   home.file.".local/bin/claude-remote" = {

--- a/environments/agent-interactive/claude-remote.nix
+++ b/environments/agent-interactive/claude-remote.nix
@@ -1,15 +1,9 @@
-{ pkgs, ... }:
+{ ... }:
 {
   # `claude-remote <project> <session>` starts a Remote Control Claude session in
   # one of the cloned repos; the /dotfiles-claude-remote skill launches it under
   # tmux from inside an already-running session. Interactive hosts only — an
   # unattended host has no operator to pick the remote session up.
-
-  # claude-remote edits Claude's own config (`$CLAUDE_CONFIG_DIR/.claude.json`,
-  # `~/.claude.json` unset) to pre-accept the workspace trust prompt; nothing
-  # else in the bundle puts jq on PATH.
-  home.packages = [ pkgs.jq ];
-
   home.file.".local/bin/claude-remote" = {
     source = ./bin/claude-remote;
     executable = true;

--- a/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
+++ b/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
@@ -11,20 +11,26 @@ separate session, not a subagent, so nothing here can talk to it afterwards.
 
 1. `$ARGUMENTS` is `<project> <session>` — both are required. The session
    identifier is what distinguishes concurrent sessions on the same repo (e.g.
-   `review`, `dev-container-bug`); it may contain only letters, digits, `_` and
-   `-`. Ask for whichever is missing, listing the directories in `~/projects`
-   when the project is the missing one.
-2. If `~/projects/<project>` is not a directory, say so, list the available
+   `review`, `dev-container-bug`). Ask for whichever is missing, listing the
+   directories in `~/projects` when the project is the missing one.
+2. Both may contain only letters, digits, `_` and `-` — they become one tmux
+   session name, which can hold neither `.` nor `:`. Reject a bad identifier
+   here and ask for another; `claude-remote` also rejects it, but only after
+   `tmux new-session` has already returned, which reads as a session that
+   started and vanished.
+3. If `~/projects/<project>` is not a directory, say so, list the available
    projects, and stop.
-3. If `tmux has-session -t remote-<project>-<session>` succeeds, one is already
-   running — report it and stop rather than starting a second.
-4. Otherwise start it:
+4. If `tmux has-session -t "remote-<project>-<session>"` succeeds, one is
+   already running — report it and stop rather than starting a second.
+5. Otherwise start it:
 
        tmux new-session -d -s "remote-<project>-<session>" claude-remote <project> <session>
 
-   `claude-remote` accepts the workspace trust prompt on its own for a project
-   Claude has never run in, since nothing detached can answer it.
+   For a project Claude has never run in, `claude-remote` accepts the workspace
+   trust prompt itself, since nothing detached can answer it. It warns on stderr
+   and launches anyway if it cannot (no jq, unreadable config) — a session that
+   stops at the prompt can still be answered by attaching to it.
 
-5. Report the Remote Control name (`remote-<project>-<session>`, how it appears
+6. Report the Remote Control name (`remote-<project>-<session>`, how it appears
    on claude.ai and mobile) and `tmux attach -t remote-<project>-<session>` for
    taking it over from a shell here.

--- a/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
+++ b/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
@@ -6,8 +6,8 @@ description: Start a Remote Control Claude session for one of the ~/projects rep
 # dotfiles-claude-remote
 
 Launch a second Claude session in `~/projects/<project>` with Remote Control
-enabled. It runs detached under tmux, so it outlives this session; it is a
-separate session, not a subagent, so nothing here can talk to it afterwards.
+enabled. It runs detached under tmux, so it outlives this session, and it is a
+separate session rather than a subagent of this one.
 
 1. `$ARGUMENTS` is `<project> <session>` — both are required. The session
    identifier is what distinguishes concurrent sessions on the same repo (e.g.
@@ -20,17 +20,14 @@ separate session, not a subagent, so nothing here can talk to it afterwards.
    started and vanished.
 3. If `~/projects/<project>` is not a directory, say so, list the available
    projects, and stop.
-4. If `tmux has-session -t "remote-<project>-<session>"` succeeds, one is
-   already running — report it and stop rather than starting a second.
+4. If `tmux has-session -t "=remote-<project>-<session>"` succeeds, one is
+   already running — report it and stop rather than starting a second. Keep the
+   leading `=`: without it tmux matches a target by prefix, so the check also
+   fires for an unrelated `remote-<project>-<session>-<something>`.
 5. Otherwise start it:
 
        tmux new-session -d -s "remote-<project>-<session>" claude-remote <project> <session>
 
-   For a project Claude has never run in, `claude-remote` accepts the workspace
-   trust prompt itself, since nothing detached can answer it. It warns on stderr
-   and launches anyway if it cannot (no jq, unreadable config) — a session that
-   stops at the prompt can still be answered by attaching to it.
-
 6. Report the Remote Control name (`remote-<project>-<session>`, how it appears
-   on claude.ai and mobile) and `tmux attach -t remote-<project>-<session>` for
-   taking it over from a shell here.
+   on claude.ai and mobile) and `tmux attach -t "=remote-<project>-<session>"`
+   for taking it over from a shell here.

--- a/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
+++ b/environments/agent-interactive/claude/skills/dotfiles-claude-remote/SKILL.md
@@ -1,24 +1,30 @@
 ---
 name: dotfiles-claude-remote
-description: Start a Remote Control Claude session for one of the ~/projects repos in a detached tmux session, so it can be driven from claude.ai or the mobile app. Invoke as `/dotfiles-claude-remote <project>`.
+description: Start a Remote Control Claude session for one of the ~/projects repos in a detached tmux session, so it can be driven from claude.ai or the mobile app. Invoke as `/dotfiles-claude-remote <project> <session>`.
 ---
 
 # dotfiles-claude-remote
 
-Launch a second Claude session in `~/projects/$ARGUMENTS` with Remote Control
+Launch a second Claude session in `~/projects/<project>` with Remote Control
 enabled. It runs detached under tmux, so it outlives this session; it is a
 separate session, not a subagent, so nothing here can talk to it afterwards.
 
-1. Take the project name from `$ARGUMENTS`. If empty, list the directories in
-   `~/projects` and ask which one.
+1. `$ARGUMENTS` is `<project> <session>` — both are required. The session
+   identifier is what distinguishes concurrent sessions on the same repo (e.g.
+   `review`, `dev-container-bug`); it may contain only letters, digits, `_` and
+   `-`. Ask for whichever is missing, listing the directories in `~/projects`
+   when the project is the missing one.
 2. If `~/projects/<project>` is not a directory, say so, list the available
    projects, and stop.
-3. If `tmux has-session -t remote-<project>` succeeds, one is already running —
-   report it and stop rather than starting a second.
+3. If `tmux has-session -t remote-<project>-<session>` succeeds, one is already
+   running — report it and stop rather than starting a second.
 4. Otherwise start it:
 
-       tmux new-session -d -s "remote-<project>" claude-remote <project>
+       tmux new-session -d -s "remote-<project>-<session>" claude-remote <project> <session>
 
-5. Report the Remote Control name (`remote-<project>`, how it appears on
-   claude.ai and mobile) and `tmux attach -t remote-<project>` for taking it
-   over from a shell here.
+   `claude-remote` accepts the workspace trust prompt on its own for a project
+   Claude has never run in, since nothing detached can answer it.
+
+5. Report the Remote Control name (`remote-<project>-<session>`, how it appears
+   on claude.ai and mobile) and `tmux attach -t remote-<project>-<session>` for
+   taking it over from a shell here.


### PR DESCRIPTION
## Motivation

`/dotfiles-claude-remote` took only a project name, so the tmux and Remote
Control session names were `remote-<project>` — one session per repo, and a
second one on the same repo collides. It now takes a session identifier too:
`remote-<project>-<session>`.

Both arguments are restricted to `[A-Za-z0-9_-]`, since the pair becomes a
single tmux session name and tmux reads `.` and `:` as window/pane addressing.

Trust-prompt auto-accept was part of an earlier revision and was dropped at the
operator's request; this branch changes no Claude state.

## Test plan

- `shellcheck` and `bash -n` on `bin/claude-remote`; `nix-instantiate --parse`
  on `claude-remote.nix`.
- Argument validation, run by hand: no args, project only, three args, a `.` in
  either argument, a `../` project, and a nonexistent project — each exits with
  the documented code and usage. Non-ASCII (`revué`) rejected under a UTF-8
  locale.
- `tmux has-session -t remote-x-review` confirmed to match the unrelated
  `remote-x-review-extra` by prefix, and `-t "=remote-x-review"` confirmed not
  to — which is why the skill now uses the `=` sigil.
- Not run: an end-to-end `claude-remote` launch. The flake does not evaluate in
  this container (`core/host.nix` is untracked), so `nix eval` was not part of
  the check.
