### PR TITLE
feat(claude): enable channels in managed settings

### DIFF
--- a/core/common/agent/claude.nix
+++ b/core/common/agent/claude.nix
@@ -22,6 +22,12 @@ let
   # play-sound shim plays the sound on the connecting client).
   managedSettings = jsonFormat.generate "claude-managed-settings.json" (
     lib.recursiveUpdate (import ../claude/plugins.nix) (dispatchOptions // {
+      # Channels are blocked wherever managed settings are deployed until this
+      # key is set, and the block is silent: the MCP server connects, its tools
+      # work, and every event it pushes is dropped with no error back to it.
+      # dispatch's orchestration is push-driven, so without this its scheduler
+      # emits work orders into nothing and sessions sit idle forever.
+      channelsEnabled = true;
       hooks = {
         Stop = [{ hooks = [{ type = "command"; command = "play-sound Morse 0.4"; }]; }];
         Notification = [{ hooks = [{ type = "command"; command = "play-sound Ping 0.35"; }]; }];


### PR DESCRIPTION
## Motivation

Channels are blocked wherever managed settings are deployed until `channelsEnabled` is set, and the block is **silent**: the MCP server connects, its tools work, and every event it pushes is dropped with no error returned to it.

dispatch's orchestration is push-driven — the server emits work orders and PR events over a channel — so without this key its scheduler emits into nothing and its sessions sit idle indefinitely. That produced hours of `acked_at: null` server rows on the agent hosts and, indirectly, a runaway: a correctly-idle session looked stalled to the supervisor, which prodded it into driving itself from the unclaimed queue.

Per the [channels docs](https://code.claude.com/docs/en/channels#enterprise-controls), a Console org that deploys managed settings has channels blocked until this key is set. The file generated here is installed at `/etc/claude-code/managed-settings.json`, which is exactly that case.

## Verification

Set by hand on an agent host before writing this. With it in place (and the host naming the channel at launch) the session shows:

```
▎ Channels (experimental) messages from plugin:dispatch@agentic inject directly in this session
← dispatch: Run `dispatch mcp ack --server 6bb22fb4-…
← dispatch: The head commit moved to 752fc946…
← dispatch: Launch a pr-worker agent for PR item …
```

The probe, PR observations, and work orders all arrive. Without it, nothing does.

## Scope

This only unblocks the policy. A session must still **name** the channel at launch — being in the MCP config is not enough — and that is the consuming host's job. homelab's `ai-dev-supervise` does it on `fix/ai-dev-no-fallback-nudge`.